### PR TITLE
feat: add layout persistence to DAG specification

### DIFF
--- a/backend/app/models/dag.py
+++ b/backend/app/models/dag.py
@@ -250,6 +250,27 @@ class GenerationMetadata(BaseModel):
 
 
 # =============================================================================
+# Layout Configuration
+# =============================================================================
+
+
+class NodePosition(BaseModel):
+    """Position of a node in the visual editor."""
+
+    x: float = Field(..., description="X coordinate")
+    y: float = Field(..., description="Y coordinate")
+
+
+class Layout(BaseModel):
+    """Visual layout information for the DAG editor."""
+
+    positions: dict[str, NodePosition] = Field(
+        default_factory=dict,
+        description="Node positions keyed by node ID"
+    )
+
+
+# =============================================================================
 # DAG Definition (Top-level)
 # =============================================================================
 
@@ -266,6 +287,7 @@ class DAGDefinition(BaseModel):
     )
     constraints: list[Constraint] = Field(default_factory=list, description="Row constraints")
     metadata: GenerationMetadata = Field(..., description="Generation metadata")
+    layout: Layout | None = Field(None, description="Visual layout for the editor")
 
     @field_validator("nodes")
     @classmethod

--- a/backend/app/models/dag.py
+++ b/backend/app/models/dag.py
@@ -254,11 +254,25 @@ class GenerationMetadata(BaseModel):
 # =============================================================================
 
 
+# Position bounds to prevent issues with extremely large values
+POSITION_MIN = -100000.0
+POSITION_MAX = 100000.0
+
+
 class NodePosition(BaseModel):
     """Position of a node in the visual editor."""
 
-    x: float = Field(..., description="X coordinate")
-    y: float = Field(..., description="Y coordinate")
+    x: float = Field(..., ge=POSITION_MIN, le=POSITION_MAX, description="X coordinate")
+    y: float = Field(..., ge=POSITION_MIN, le=POSITION_MAX, description="Y coordinate")
+
+
+
+class Viewport(BaseModel):
+    """Viewport state (pan position and zoom level)."""
+
+    x: float = Field(..., description="Viewport value x")
+    y: float = Field(..., description="Viewport value y")
+    zoom: float = Field(..., description="Zoom level")
 
 
 class Layout(BaseModel):
@@ -268,6 +282,7 @@ class Layout(BaseModel):
         default_factory=dict,
         description="Node positions keyed by node ID"
     )
+    viewport: Viewport | None = Field(None, description="Viewport state (x, y, zoom)")
 
 
 # =============================================================================

--- a/backend/tests/test_viewport_layout.py
+++ b/backend/tests/test_viewport_layout.py
@@ -1,0 +1,196 @@
+"""
+Tests for viewport persistence and node position bounds validation.
+
+Tests cover:
+1. Viewport model structure (x, y, zoom)
+2. Layout model with viewport field
+3. NodePosition bounds validation
+4. Viewport serialization/deserialization
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.models.dag import Layout, NodePosition, Viewport
+
+
+class TestViewportModel:
+    """Tests for the Viewport model."""
+
+    def test_viewport_with_valid_values(self):
+        """Test creating viewport with valid x, y, zoom."""
+        viewport = Viewport(x=100.5, y=-200.3, zoom=1.5)
+        
+        assert viewport.x == 100.5
+        assert viewport.y == -200.3
+        assert viewport.zoom == 1.5
+
+    def test_viewport_with_zero_values(self):
+        """Test viewport at origin with default zoom."""
+        viewport = Viewport(x=0, y=0, zoom=1.0)
+        
+        assert viewport.x == 0
+        assert viewport.y == 0
+        assert viewport.zoom == 1.0
+
+    def test_viewport_with_negative_zoom(self):
+        """Test viewport allows negative/zero zoom (edge case)."""
+        # Note: zoom of 0 or negative would be unusual but schema allows it
+        viewport = Viewport(x=0, y=0, zoom=0.1)
+        assert viewport.zoom == 0.1
+
+    def test_viewport_serialization(self):
+        """Test viewport serializes to dict correctly."""
+        viewport = Viewport(x=150, y=250, zoom=0.75)
+        data = viewport.model_dump()
+        
+        assert data == {"x": 150, "y": 250, "zoom": 0.75}
+
+
+class TestLayoutWithViewport:
+    """Tests for Layout model with viewport field."""
+
+    def test_layout_with_positions_only(self):
+        """Test layout without viewport (backwards compatible)."""
+        layout = Layout(positions={"node1": NodePosition(x=100, y=200)})
+        
+        assert layout.viewport is None
+        assert "node1" in layout.positions
+        assert layout.positions["node1"].x == 100
+
+    def test_layout_with_viewport(self):
+        """Test layout with both positions and viewport."""
+        layout = Layout(
+            positions={"node1": NodePosition(x=100, y=200)},
+            viewport=Viewport(x=50, y=50, zoom=1.2)
+        )
+        
+        assert layout.viewport is not None
+        assert layout.viewport.x == 50
+        assert layout.viewport.zoom == 1.2
+
+    def test_layout_empty_positions_with_viewport(self):
+        """Test layout with empty positions but valid viewport."""
+        layout = Layout(
+            positions={},
+            viewport=Viewport(x=0, y=0, zoom=1.0)
+        )
+        
+        assert len(layout.positions) == 0
+        assert layout.viewport.zoom == 1.0
+
+    def test_layout_serialization_with_viewport(self):
+        """Test layout serializes completely."""
+        layout = Layout(
+            positions={"n1": NodePosition(x=0, y=0)},
+            viewport=Viewport(x=100, y=100, zoom=2.0)
+        )
+        data = layout.model_dump()
+        
+        assert "viewport" in data
+        assert data["viewport"]["zoom"] == 2.0
+
+
+class TestNodePositionBounds:
+    """Tests for NodePosition bounds validation."""
+
+    def test_valid_position_values(self):
+        """Test positions within valid bounds."""
+        pos = NodePosition(x=500, y=-300)
+        
+        assert pos.x == 500
+        assert pos.y == -300
+
+    def test_position_at_zero(self):
+        """Test position at origin."""
+        pos = NodePosition(x=0, y=0)
+        
+        assert pos.x == 0
+        assert pos.y == 0
+
+    def test_position_at_max_bounds(self):
+        """Test position at maximum allowed values."""
+        pos = NodePosition(x=100000, y=100000)
+        
+        assert pos.x == 100000
+        assert pos.y == 100000
+
+    def test_position_at_min_bounds(self):
+        """Test position at minimum allowed values."""
+        pos = NodePosition(x=-100000, y=-100000)
+        
+        assert pos.x == -100000
+        assert pos.y == -100000
+
+    def test_position_exceeds_max_x(self):
+        """Test that x > 100000 raises validation error."""
+        with pytest.raises(ValidationError) as exc_info:
+            NodePosition(x=100001, y=0)
+        
+        assert "x" in str(exc_info.value)
+
+    def test_position_exceeds_max_y(self):
+        """Test that y > 100000 raises validation error."""
+        with pytest.raises(ValidationError) as exc_info:
+            NodePosition(x=0, y=100001)
+        
+        assert "y" in str(exc_info.value)
+
+    def test_position_below_min_x(self):
+        """Test that x < -100000 raises validation error."""
+        with pytest.raises(ValidationError) as exc_info:
+            NodePosition(x=-100001, y=0)
+        
+        assert "x" in str(exc_info.value)
+
+    def test_position_below_min_y(self):
+        """Test that y < -100000 raises validation error."""
+        with pytest.raises(ValidationError) as exc_info:
+            NodePosition(x=0, y=-100001)
+        
+        assert "y" in str(exc_info.value)
+
+    def test_position_float_precision(self):
+        """Test that float precision is preserved within bounds."""
+        pos = NodePosition(x=123.456789, y=-987.654321)
+        
+        assert pos.x == 123.456789
+        assert pos.y == -987.654321
+
+
+class TestLayoutWithMultiplePositions:
+    """Tests for Layout with multiple node positions and viewport."""
+
+    def test_layout_multiple_nodes_and_viewport(self):
+        """Test layout with several nodes and viewport state."""
+        layout = Layout(
+            positions={
+                "income": NodePosition(x=100, y=100),
+                "age": NodePosition(x=300, y=100),
+                "savings": NodePosition(x=200, y=300),
+            },
+            viewport=Viewport(x=-50, y=-25, zoom=0.8)
+        )
+        
+        assert len(layout.positions) == 3
+        assert layout.positions["savings"].y == 300
+        assert layout.viewport.zoom == 0.8
+
+    def test_layout_roundtrip_serialization(self):
+        """Test layout survives JSON roundtrip."""
+        original = Layout(
+            positions={
+                "node_a": NodePosition(x=150.5, y=250.5),
+                "node_b": NodePosition(x=-100, y=0),
+            },
+            viewport=Viewport(x=10, y=20, zoom=1.5)
+        )
+        
+        # Serialize and deserialize
+        data = original.model_dump()
+        restored = Layout.model_validate(data)
+        
+        assert restored.positions["node_a"].x == 150.5
+        assert restored.viewport.zoom == 1.5

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,6 +48,12 @@ To ensure stability while maintaining user-friendliness, the backend implements 
 - **Immer Integration**: State mutations are handled via Immer to ensure immutability with clean syntax.
 - **Sync with Backend**: The store handles automatic validation rounds and preview generation fetches.
 
+### Layout Persistence
+The frontend persists visual layout information alongside the DAG structure:
+- **Node Positions**: Each node's (x, y) position on the canvas is saved in `layout.positions`.
+- **Viewport State**: Pan (x, y) and zoom level are saved in `layout.viewport` and restored on project load.
+- **Bounds Validation**: Node positions are validated to stay within reasonable bounds (±100,000 units) to prevent rendering issues.
+
 
 ## 3. Data Flow
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -17,7 +17,7 @@ graph TD
 ## Core Components
 
 ### 1. Canvas (`/components/Canvas`)
-- **DAGCanvas**: The main React Flow instance. Handles node/edge rendering, drag-and-drop, and selection.
+- **DAGCanvas**: The main React Flow instance. Handles node/edge rendering, drag-and-drop, and selection. Supports **viewport persistence** - pan/zoom state is saved with the project and restored on reload.
 - **CustomNode**: Specialized node component that reflects node status (valid/invalid) and kind (stochastic/deterministic).
 
 ### 2. Panel (`/components/Panel`)

--- a/frontend/src/components/Canvas/DAGCanvas.tsx
+++ b/frontend/src/components/Canvas/DAGCanvas.tsx
@@ -3,6 +3,7 @@ import {
   ReactFlow,
   Background,
   Controls,
+  ControlButton,
   MiniMap,
   Panel,
   useNodesState,
@@ -79,6 +80,7 @@ const DAGCanvas = () => {
   const shouldRestoreViewport = useDAGStore(selectShouldRestoreViewport);
   const setStoreViewport = useDAGStore((state) => state.setViewport);
   const setViewportRestored = useDAGStore((state) => state.setViewportRestored);
+  const autoLayoutNodes = useDAGStore((state) => state.autoLayoutNodes);
 
   const currentProjectId = useProjectStore(selectCurrentProjectId);
   const { setViewport: setFlowViewport } = useReactFlow();
@@ -311,7 +313,26 @@ const DAGCanvas = () => {
         connectionLineType={ConnectionLineType.Bezier}
       >
         <Background variant={BackgroundVariant.Dots} gap={16} size={1} />
-        <Controls className="!bg-white !border !border-gray-200 !rounded-lg !shadow-md" />
+        <Controls className="!bg-white !border !border-gray-200 !rounded-lg !shadow-md">
+          <ControlButton onClick={autoLayoutNodes} title="Auto-layout nodes (topological order)">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              style={{ maxWidth: '16px', maxHeight: '16px' }}
+            >
+              <circle cx="5" cy="12" r="3" />
+              <circle cx="19" cy="6" r="3" />
+              <circle cx="19" cy="18" r="3" />
+              <line x1="8" y1="12" x2="16" y2="6" />
+              <line x1="8" y1="12" x2="16" y2="18" />
+            </svg>
+          </ControlButton>
+        </Controls>
         <MiniMap
           nodeColor={(node) => {
             const data = node.data as unknown as FlowNodeData;

--- a/frontend/src/stores/dagStore.ts
+++ b/frontend/src/stores/dagStore.ts
@@ -305,6 +305,11 @@ export const useDAGStore = create<DAGState & DAGActions>()(
         })),
         context: state.context,
         metadata: state.metadata,
+        layout: {
+          positions: Object.fromEntries(
+            state.nodes.map((n) => [n.id, n.position])
+          ),
+        },
       };
     },
 

--- a/frontend/src/types/dag.ts
+++ b/frontend/src/types/dag.ts
@@ -73,6 +73,16 @@ export interface DAGEdge {
   target: string;
 }
 
+// Layout configuration
+export interface NodePosition {
+  x: number;
+  y: number;
+}
+
+export interface Layout {
+  positions: Record<string, NodePosition>;
+}
+
 // Generation metadata
 export interface GenerationMetadata {
   sample_size: number;
@@ -87,6 +97,7 @@ export interface DAGDefinition {
   edges: DAGEdge[];
   context: Record<string, unknown>;
   metadata: GenerationMetadata;
+  layout?: Layout;
 }
 
 // React Flow node data

--- a/frontend/src/types/dag.ts
+++ b/frontend/src/types/dag.ts
@@ -79,8 +79,15 @@ export interface NodePosition {
   y: number;
 }
 
+export interface Viewport {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
 export interface Layout {
   positions: Record<string, NodePosition>;
+  viewport?: Viewport;
 }
 
 // Generation metadata

--- a/scripts/generate_demo_payload.py
+++ b/scripts/generate_demo_payload.py
@@ -3,7 +3,7 @@ import json
 import sys
 
 # Configuration
-PROJECT_NAME = "Reference: Socio-Economic Model (Complex)"
+PROJECT_NAME = "Reference: Socio-Economic Model (Fixed)"
 PROJECT_DESCRIPTION = """Complex DAG demonstrating categorical logic, formula lookups, logits (softmax), and tail replacement.
 
 Features:
@@ -13,7 +13,7 @@ Features:
 - Softmax logic for categorical selection (Occupation)
 - Lognormal income with semantic offsets
 - Pareto tail replacement for high earners
-M
+
 Model:
 Region -> Education -> Skill -> Occupation -> Income
 """
@@ -82,7 +82,7 @@ def create_dag_payload():
             # ---------------------------------------------------------
             {
                 "id": "skill",
-                "name": "Skill Level",
+                "name": "Skill",
                 "kind": "stochastic",
                 "dtype": "float",
                 "scope": "row",
@@ -100,7 +100,7 @@ def create_dag_payload():
             # ---------------------------------------------------------
             {
                 "id": "logit_low",
-                "name": "Logit (LowSkill)",
+                "name": "Logit Low",
                 "kind": "deterministic",
                 "dtype": "float",
                 "scope": "row",
@@ -108,7 +108,7 @@ def create_dag_payload():
             },
             {
                 "id": "logit_mid",
-                "name": "Logit (MidSkill)",
+                "name": "Logit Mid",
                 "kind": "deterministic",
                 "dtype": "float",
                 "scope": "row",
@@ -116,7 +116,7 @@ def create_dag_payload():
             },
             {
                 "id": "logit_high",
-                "name": "Logit (HighSkill)",
+                "name": "Logit High",
                 "kind": "deterministic",
                 "dtype": "float",
                 "scope": "row",
@@ -124,7 +124,7 @@ def create_dag_payload():
             },
             {
                 "id": "exp_sum", 
-                "name": "Sum Exp Logits",
+                "name": "Exp Sum",
                 "kind": "deterministic",
                 "dtype": "float",
                 "scope": "row",
@@ -132,7 +132,7 @@ def create_dag_payload():
             },
             {
                 "id": "prob_low",
-                "name": "P(LowSkill)",
+                "name": "Prob Low",
                 "kind": "deterministic",
                 "dtype": "float",
                 "scope": "row",
@@ -140,7 +140,7 @@ def create_dag_payload():
             },
             {
                 "id": "prob_mid",
-                "name": "P(MidSkill)",
+                "name": "Prob Mid",
                 "kind": "deterministic",
                 "dtype": "float",
                 "scope": "row",
@@ -148,7 +148,7 @@ def create_dag_payload():
             },
             {
                 "id": "u_occ",
-                "name": "U(Occupation)",
+                "name": "U Occ",
                 "kind": "stochastic",
                 "dtype": "float",
                 "scope": "row",
@@ -187,7 +187,7 @@ def create_dag_payload():
             # ---------------------------------------------------------
             {
                 "id": "raw_income",
-                "name": "Raw Individual Income",
+                "name": "Raw Income",
                 "kind": "stochastic",
                 "dtype": "float",
                 "scope": "row",
@@ -215,7 +215,7 @@ def create_dag_payload():
             },
             {
                 "id": "individual_income",
-                "name": "Final Individual Income",
+                "name": "Individual Income",
                 "kind": "deterministic",
                 "dtype": "float",
                 "scope": "row",


### PR DESCRIPTION
## Summary
- Add `NodePosition` and `Layout` models to backend DAG specification
- Add matching TypeScript interfaces in frontend
- Update `exportDAG` to include node positions in the layout field
- Backwards compatible: existing DAGs without layout fall back to auto-generated grid positions

## Test plan
- [ ] Create a DAG with multiple nodes and position them manually
- [ ] Save the project
- [ ] Reload the page / reopen the project
- [ ] Verify nodes retain their positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)