### PR TITLE
fix(ci): remove protected endpoint from smoke test

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -56,7 +56,7 @@ jobs:
           MAX_RETRIES=12
           SLEEP_SECONDS=10
           
-          ENDPOINTS=("/health" "/api/distributions" "/api/projects")
+          ENDPOINTS=("/health" "/api/distributions")
           
           for endpoint in "${ENDPOINTS[@]}"; do
             echo "Checking $endpoint..."


### PR DESCRIPTION
/api/projects now requires auth, so remove it from unauthenticated smoke test endpoints.