### PR TITLE
fix(frontend): replace native selects with custom web-native dropdowns

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -157,7 +157,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -560,7 +559,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -604,7 +602,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2064,7 +2061,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2204,7 +2202,6 @@
       "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2215,7 +2212,6 @@
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2226,7 +2222,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2276,7 +2271,6 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -2699,7 +2693,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2750,6 +2743,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2909,7 +2903,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3182,7 +3175,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3309,7 +3301,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3481,7 +3474,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4063,7 +4055,6 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.3.tgz",
       "integrity": "sha512-6jQTc5z0KJFtr1UgFpIL3N9XSC3saRaI9PwWtzM2pSqkNGtiNkYY2OSwkOGDK2XcTRcLb1pi/aNkKZz0nxVH4Q==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -4187,7 +4178,6 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -4606,6 +4596,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4844,7 +4835,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4871,7 +4861,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4920,6 +4909,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4935,6 +4925,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4963,7 +4954,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4973,7 +4963,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4986,7 +4975,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -5364,7 +5354,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5460,7 +5449,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5763,7 +5751,6 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/components/MainTabs/PipelineView.tsx
+++ b/frontend/src/components/MainTabs/PipelineView.tsx
@@ -16,10 +16,10 @@ import {
     Play,
     PlusCircle,
     RefreshCw,
-    ChevronDown,
     Sparkles,
     X,
 } from 'lucide-react';
+import { Dropdown, type DropdownOption } from '../common';
 import { FormulaBar, RecipePanel, ModelsPanel } from '../Pipeline';
 import { PreviewTable } from '../Preview/PreviewTable';
 import {
@@ -350,25 +350,19 @@ export const PipelineView = () => {
                             {/* Limit selector */}
                             <div className="flex items-center gap-2">
                                 <label className="text-xs text-gray-500 font-medium">Rows:</label>
-                                <div className="relative">
-                                    <select
-                                        value={materializeLimit}
-                                        onChange={(e) =>
-                                            setMaterializeLimit(parseInt(e.target.value))
-                                        }
-                                        className="appearance-none bg-gray-50 border border-gray-200 rounded-lg px-3 py-1.5 pr-8 text-xs font-medium focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all cursor-pointer"
-                                    >
-                                        <option value={100}>100</option>
-                                        <option value={500}>500</option>
-                                        <option value={1000}>1,000</option>
-                                        <option value={5000}>5,000</option>
-                                        <option value={10000}>10,000</option>
-                                    </select>
-                                    <ChevronDown
-                                        size={12}
-                                        className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none"
-                                    />
-                                </div>
+                                <Dropdown
+                                    options={[
+                                        { value: 100, label: '100' },
+                                        { value: 500, label: '500' },
+                                        { value: 1000, label: '1,000' },
+                                        { value: 5000, label: '5,000' },
+                                        { value: 10000, label: '10,000' },
+                                    ] as DropdownOption<number>[]}
+                                    value={materializeLimit}
+                                    onChange={setMaterializeLimit}
+                                    size="sm"
+                                    className="w-24"
+                                />
                             </div>
 
                             {/* Materialize button */}

--- a/frontend/src/components/Pipeline/ModelsPanel.tsx
+++ b/frontend/src/components/Pipeline/ModelsPanel.tsx
@@ -39,6 +39,7 @@ import {
     selectPipelineSchema,
     selectCurrentVersionId,
 } from '../../stores/pipelineStore';
+import { Dropdown, type DropdownOption } from '../common';
 
 // Helper to map icon names to Lucide components
 const ModelIcon = ({ name, size = 16, className = "" }: { name?: string; size?: number; className?: string }) => {
@@ -280,27 +281,31 @@ export const ModelsPanel = () => {
                     <label className="block text-xs font-medium text-gray-600 mb-1">
                         Model Type
                     </label>
-                    <div className="relative">
-                        <select
-                            value={selectedModel}
-                            onChange={(e) => setSelectedModel(e.target.value)}
-                            disabled={isLoadingModels}
-                            className="w-full appearance-none bg-gray-50 border border-gray-300 rounded-md pl-9 pr-8 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
-                        >
-                            {modelTypes.map((m) => (
-                                <option key={m.name} value={m.name}>
-                                    {m.display_name} {m.coming_soon ? '(Coming Soon)' : ''}
-                                </option>
-                            ))}
-                        </select>
-                        <div className="absolute left-3 top-1/2 -translate-y-1/2 text-purple-600 pointer-events-none">
-                            <ModelIcon name={currentModelType?.icon} size={14} />
-                        </div>
-                        <ChevronDown
-                            size={14}
-                            className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none"
-                        />
-                    </div>
+                    <Dropdown
+                        options={modelTypes.map((m): DropdownOption<string> => ({
+                            value: m.name,
+                            label: `${m.display_name}${m.coming_soon ? ' (Coming Soon)' : ''}`,
+                            icon: <ModelIcon name={m.icon} size={14} />,
+                            disabled: m.coming_soon,
+                        }))}
+                        value={selectedModel}
+                        onChange={setSelectedModel}
+                        disabled={isLoadingModels || isFitting}
+                        icon={<ModelIcon name={currentModelType?.icon} size={14} />}
+                        renderOption={(option, isSelected) => (
+                            <div
+                                className={`
+                                    flex items-center gap-2 px-3 py-2
+                                    ${isSelected ? 'bg-purple-50 text-purple-700' : 'text-gray-700'}
+                                    ${option.disabled ? 'opacity-50' : 'hover:bg-gray-50'}
+                                    transition-colors
+                                `}
+                            >
+                                <span className="text-purple-600">{option.icon}</span>
+                                <span className="flex-1 text-sm">{option.label}</span>
+                            </div>
+                        )}
+                    />
                     <div className="flex items-center gap-2 mt-1">
                         {currentModelType && (
                             <p className="text-[10px] bg-purple-100 text-purple-700 px-1.5 py-0.5 rounded font-medium uppercase tracking-wider">
@@ -389,29 +394,18 @@ export const ModelsPanel = () => {
                                         <span className="text-xs text-gray-500">Enabled</span>
                                     </label>
                                 ) : isChoice ? (
-                                    <div className="relative">
-                                        <select
-                                            value={modelParams[p.name] === null ? 'null' : String(modelParams[p.name] ?? p.default)}
-                                            onChange={(e) => {
-                                                const val = e.target.value;
-                                                handleUpdateParam(p.name, val === 'null' ? null : val, p.type);
-                                            }}
-                                            className={`w-full appearance-none bg-white border rounded-md pl-2 pr-8 py-1.5 text-xs focus:outline-none focus:ring-1 ${hasError
-                                                ? 'border-red-300 focus:ring-red-500'
-                                                : 'border-gray-300 focus:ring-purple-500'
-                                                }`}
-                                        >
-                                            {p.choices?.map((choice) => (
-                                                <option key={choice === null ? 'null' : String(choice)} value={choice === null ? 'null' : String(choice)}>
-                                                    {choice === null ? 'None' : String(choice)}
-                                                </option>
-                                            ))}
-                                        </select>
-                                        <ChevronDown
-                                            size={12}
-                                            className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none"
-                                        />
-                                    </div>
+                                    <Dropdown
+                                        options={(p.choices ?? []).map((choice): DropdownOption<string> => ({
+                                            value: choice === null ? 'null' : String(choice),
+                                            label: choice === null ? 'None' : String(choice),
+                                        }))}
+                                        value={modelParams[p.name] === null ? 'null' : String(modelParams[p.name] ?? p.default)}
+                                        onChange={(val) => {
+                                            handleUpdateParam(p.name, val === 'null' ? null : val, p.type);
+                                        }}
+                                        size="sm"
+                                        error={hasError}
+                                    />
                                 ) : (
                                     <>
                                         <input
@@ -509,24 +503,18 @@ export const ModelsPanel = () => {
                         <Target size={12} />
                         Target Column
                     </label>
-                    <div className="relative">
-                        <select
-                            value={targetColumn}
-                            onChange={(e) => setTargetColumn(e.target.value)}
-                            className="w-full appearance-none bg-gray-50 border border-gray-300 rounded-md pl-3 pr-8 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
-                        >
-                            <option value="">Select target...</option>
-                            {numericColumns.map((col) => (
-                                <option key={col.name} value={col.name}>
-                                    {col.name}
-                                </option>
-                            ))}
-                        </select>
-                        <ChevronDown
-                            size={14}
-                            className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none"
-                        />
-                    </div>
+                    <Dropdown
+                        options={[
+                            { value: '', label: 'Select target...' },
+                            ...numericColumns.map((col): DropdownOption<string> => ({
+                                value: col.name,
+                                label: col.name,
+                            })),
+                        ]}
+                        value={targetColumn}
+                        onChange={setTargetColumn}
+                        placeholder="Select target..."
+                    />
                 </div>
 
                 {/* Feature columns */}

--- a/frontend/src/components/common/Dropdown.tsx
+++ b/frontend/src/components/common/Dropdown.tsx
@@ -3,7 +3,7 @@
  * Provides consistent styling and behavior across all browsers.
  */
 
-import { useState, useRef, useEffect, ReactNode } from 'react';
+import { useState, useRef, useEffect, type ReactNode } from 'react';
 import { ChevronDown, Check } from 'lucide-react';
 
 export interface DropdownOption<T = string> {

--- a/frontend/src/components/common/Dropdown.tsx
+++ b/frontend/src/components/common/Dropdown.tsx
@@ -1,0 +1,218 @@
+/**
+ * Custom Dropdown component - a web-native replacement for native select elements.
+ * Provides consistent styling and behavior across all browsers.
+ */
+
+import { useState, useRef, useEffect, ReactNode } from 'react';
+import { ChevronDown, Check } from 'lucide-react';
+
+export interface DropdownOption<T = string> {
+    value: T;
+    label: string;
+    icon?: ReactNode;
+    disabled?: boolean;
+    description?: string;
+}
+
+interface DropdownProps<T = string> {
+    options: DropdownOption<T>[];
+    value: T;
+    onChange: (value: T) => void;
+    placeholder?: string;
+    disabled?: boolean;
+    error?: boolean;
+    size?: 'sm' | 'md';
+    className?: string;
+    icon?: ReactNode;
+    renderOption?: (option: DropdownOption<T>, isSelected: boolean) => ReactNode;
+    renderValue?: (option: DropdownOption<T> | undefined) => ReactNode;
+}
+
+export function Dropdown<T = string>({
+    options,
+    value,
+    onChange,
+    placeholder = 'Select...',
+    disabled = false,
+    error = false,
+    size = 'md',
+    className = '',
+    icon,
+    renderOption,
+    renderValue,
+}: DropdownProps<T>) {
+    const [isOpen, setIsOpen] = useState(false);
+    const dropdownRef = useRef<HTMLDivElement>(null);
+    const listRef = useRef<HTMLDivElement>(null);
+
+    const selectedOption = options.find((opt) => opt.value === value);
+
+    // Close dropdown when clicking outside
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+                setIsOpen(false);
+            }
+        };
+
+        if (isOpen) {
+            document.addEventListener('mousedown', handleClickOutside);
+        }
+
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+        };
+    }, [isOpen]);
+
+    // Scroll selected option into view when opening
+    useEffect(() => {
+        if (isOpen && listRef.current && selectedOption) {
+            const selectedEl = listRef.current.querySelector('[data-selected="true"]');
+            if (selectedEl) {
+                selectedEl.scrollIntoView({ block: 'nearest' });
+            }
+        }
+    }, [isOpen, selectedOption]);
+
+    // Handle keyboard navigation
+    useEffect(() => {
+        if (!isOpen) return;
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            switch (event.key) {
+                case 'Escape':
+                    setIsOpen(false);
+                    break;
+                case 'ArrowDown': {
+                    event.preventDefault();
+                    const currentIndex = options.findIndex((opt) => opt.value === value);
+                    const nextIndex = Math.min(currentIndex + 1, options.length - 1);
+                    const nextOption = options[nextIndex];
+                    if (nextOption && !nextOption.disabled) {
+                        onChange(nextOption.value);
+                    }
+                    break;
+                }
+                case 'ArrowUp': {
+                    event.preventDefault();
+                    const currentIndex = options.findIndex((opt) => opt.value === value);
+                    const prevIndex = Math.max(currentIndex - 1, 0);
+                    const prevOption = options[prevIndex];
+                    if (prevOption && !prevOption.disabled) {
+                        onChange(prevOption.value);
+                    }
+                    break;
+                }
+                case 'Enter':
+                    setIsOpen(false);
+                    break;
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [isOpen, options, value, onChange]);
+
+    const handleSelect = (option: DropdownOption<T>) => {
+        if (option.disabled) return;
+        onChange(option.value);
+        setIsOpen(false);
+    };
+
+    const sizeClasses = {
+        sm: 'py-1.5 text-xs',
+        md: 'py-2 text-sm',
+    };
+
+    const borderClasses = error
+        ? 'border-red-300 focus:ring-red-500'
+        : 'border-gray-300 focus:ring-purple-500';
+
+    return (
+        <div className={`relative ${className}`} ref={dropdownRef}>
+            {/* Trigger button */}
+            <button
+                type="button"
+                onClick={() => !disabled && setIsOpen(!isOpen)}
+                disabled={disabled}
+                className={`
+                    w-full appearance-none bg-gray-50 border rounded-md
+                    ${icon ? 'pl-9' : 'pl-3'} pr-8
+                    ${sizeClasses[size]}
+                    focus:outline-none focus:ring-2
+                    ${borderClasses}
+                    ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer hover:bg-gray-100'}
+                    text-left transition-colors
+                `}
+            >
+                {renderValue ? (
+                    renderValue(selectedOption)
+                ) : selectedOption ? (
+                    <span className="block truncate">{selectedOption.label}</span>
+                ) : (
+                    <span className="block truncate text-gray-400">{placeholder}</span>
+                )}
+            </button>
+
+            {/* Left icon */}
+            {icon && (
+                <div className="absolute left-3 top-1/2 -translate-y-1/2 text-purple-600 pointer-events-none">
+                    {icon}
+                </div>
+            )}
+
+            {/* Chevron */}
+            <ChevronDown
+                size={size === 'sm' ? 12 : 14}
+                className={`absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none transition-transform ${isOpen ? 'rotate-180' : ''}`}
+            />
+
+            {/* Dropdown menu */}
+            {isOpen && (
+                <div
+                    ref={listRef}
+                    className="absolute z-50 w-full mt-1 bg-white border border-gray-200 rounded-lg shadow-lg max-h-60 overflow-auto"
+                >
+                    {options.map((option, index) => {
+                        const isSelected = option.value === value;
+
+                        if (renderOption) {
+                            return (
+                                <div
+                                    key={index}
+                                    data-selected={isSelected}
+                                    onClick={() => handleSelect(option)}
+                                    className={`cursor-pointer ${option.disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+                                >
+                                    {renderOption(option, isSelected)}
+                                </div>
+                            );
+                        }
+
+                        return (
+                            <div
+                                key={index}
+                                data-selected={isSelected}
+                                onClick={() => handleSelect(option)}
+                                className={`
+                                    flex items-center gap-2 px-3 ${sizeClasses[size]}
+                                    ${isSelected ? 'bg-purple-50 text-purple-700' : 'text-gray-700'}
+                                    ${option.disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer hover:bg-gray-50'}
+                                    transition-colors
+                                `}
+                            >
+                                {option.icon && (
+                                    <span className="flex-shrink-0">{option.icon}</span>
+                                )}
+                                <span className="flex-1 truncate">{option.label}</span>
+                                {isSelected && (
+                                    <Check size={14} className="flex-shrink-0 text-purple-600" />
+                                )}
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -1,2 +1,4 @@
 export { ToastContainer, ToastProvider, useToast } from './Toast';
 export type { ToastMessage, ToastType } from './Toast';
+export { Dropdown } from './Dropdown';
+export type { DropdownOption } from './Dropdown';


### PR DESCRIPTION
Replace all native HTML <select> elements with a custom Dropdown
component for consistent styling and behavior across browsers.
This fixes issues where the dropdown sometimes wouldn't show up
properly and removes OS-native styling.

- Add reusable Dropdown component to common components
- Update ModelsPanel model type, hyperparameter, and target selectors
- Update PipelineView materialize limit selector
- Add proper disabled state during model training (isFitting)