### PR TITLE
feat: add automated database keepalive to prevent Supabase auto-pause

### DIFF
--- a/.github/workflows/keep-db-alive.yml
+++ b/.github/workflows/keep-db-alive.yml
@@ -1,0 +1,40 @@
+name: Keep Database Alive
+
+# Run daily at 3 AM UTC to prevent Supabase free-tier auto-pause
+on:
+  schedule:
+    - cron: '0 3 * * *'  # Daily at 3 AM UTC
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  ping-database:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install sqlalchemy psycopg2-binary
+
+      - name: Ping database
+        env:
+          DS_DATABASE_URL: ${{ secrets.DS_DATABASE_URL }}
+        run: |
+          python scripts/keep_db_alive.py
+
+      - name: Report status
+        if: always()
+        run: |
+          if [ $? -eq 0 ]; then
+            echo "✅ Database keepalive successful"
+          else
+            echo "❌ Database keepalive failed"
+            exit 1
+          fi

--- a/scripts/keep_db_alive.py
+++ b/scripts/keep_db_alive.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""
+Keep database alive by performing a lightweight query.
+
+This script makes a simple database query to prevent Supabase
+from pausing the project due to inactivity.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timezone
+
+from sqlalchemy import create_engine, text
+
+
+def ping_database(database_url: str) -> bool:
+    """Perform a lightweight database query.
+
+    Args:
+        database_url: PostgreSQL connection string
+
+    Returns:
+        True if successful, False otherwise
+    """
+    try:
+        # Create engine with short timeout
+        engine = create_engine(
+            database_url,
+            pool_pre_ping=True,
+            connect_args={"connect_timeout": 10},
+        )
+
+        # Simple query that doesn't require any tables
+        with engine.connect() as conn:
+            result = conn.execute(text("SELECT 1 as keepalive"))
+            row = result.fetchone()
+
+            if row and row[0] == 1:
+                print(f"✓ Database ping successful at {datetime.now(timezone.utc).isoformat()}")
+                return True
+            else:
+                print(f"✗ Unexpected result: {row}")
+                return False
+
+    except Exception as e:
+        print(f"✗ Database ping failed: {e}")
+        return False
+    finally:
+        engine.dispose()
+
+
+def main() -> int:
+    """Main entry point."""
+    database_url = os.getenv("DS_DATABASE_URL")
+
+    if not database_url:
+        print("Error: DS_DATABASE_URL environment variable not set")
+        return 1
+
+    # Mask password in output
+    safe_url = database_url.split("@")[1] if "@" in database_url else "unknown"
+    print(f"Pinging database at {safe_url}...")
+
+    success = ping_database(database_url)
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Add daily GitHub Actions workflow that pings the database to prevent free-tier auto-pause after 7 days of inactivity.

- Create keep_db_alive.py script for lightweight DB health check
- Add keep-db-alive.yml workflow that runs daily at 3 AM UTC
- Can also be triggered manually from Actions tab