### PR TITLE
Split save flow and add DAG version diff tracking

### DIFF
--- a/backend/alembic/versions/f3b7c5e2a1d4_add_dag_version_metadata_and_diff.py
+++ b/backend/alembic/versions/f3b7c5e2a1d4_add_dag_version_metadata_and_diff.py
@@ -1,0 +1,50 @@
+"""add dag version metadata and diff
+
+Revision ID: f3b7c5e2a1d4
+Revises: 51a385b65326
+Create Date: 2026-02-08 14:40:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "f3b7c5e2a1d4"
+down_revision = "51a385b65326"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("dag_versions") as batch_op:
+        batch_op.add_column(sa.Column("name", sa.String(length=255), nullable=True))
+        batch_op.add_column(sa.Column("description", sa.String(length=1000), nullable=True))
+        batch_op.add_column(sa.Column("parent_version_id", sa.String(length=36), nullable=True))
+        batch_op.add_column(sa.Column("dag_diff", sa.JSON(), nullable=True))
+        batch_op.create_index("ix_dag_versions_parent_version_id", ["parent_version_id"], unique=False)
+        batch_op.create_foreign_key(
+            "fk_dag_versions_parent_version_id",
+            "dag_versions",
+            ["parent_version_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+    op.create_index(
+        "uq_dag_versions_one_current_per_project",
+        "dag_versions",
+        ["project_id"],
+        unique=True,
+        sqlite_where=sa.text("is_current = 1"),
+        postgresql_where=sa.text("is_current = true"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_dag_versions_one_current_per_project", table_name="dag_versions")
+    with op.batch_alter_table("dag_versions") as batch_op:
+        batch_op.drop_constraint("fk_dag_versions_parent_version_id", type_="foreignkey")
+        batch_op.drop_index("ix_dag_versions_parent_version_id")
+        batch_op.drop_column("dag_diff")
+        batch_op.drop_column("parent_version_id")
+        batch_op.drop_column("description")
+        batch_op.drop_column("name")

--- a/backend/app/db/crud.py
+++ b/backend/app/db/crud.py
@@ -2,13 +2,20 @@
 
 from __future__ import annotations
 
+import json
+import logging
 from typing import Any
 
+import jsonpatch
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.db.models import DAGVersion, Project
 from app.models.dag import DAGDefinition
+
+logger = logging.getLogger(__name__)
+MAX_DAG_DIFF_BYTES = 100_000
 
 
 # =============================================================================
@@ -118,12 +125,16 @@ def create_version(
     db: Session,
     project_id: str,
     dag_definition: DAGDefinition,
+    name: str | None = None,
+    description: str | None = None,
     set_current: bool = True,
 ) -> DAGVersion:
     """Create a new DAG version for a project."""
     # Get next version number
     latest = get_latest_version_number(db, project_id)
     next_version = latest + 1
+
+    parent_version = get_current_version(db, project_id)
 
     # If setting as current, unset current flag from other versions
     if set_current:
@@ -132,13 +143,65 @@ def create_version(
     # Serialize DAGDefinition to dict
     dag_dict: dict[str, Any] = dag_definition.model_dump(mode="json")
 
+    dag_diff = None
+    parent_version_id = None
+    if parent_version:
+        parent_version_id = parent_version.id
+        dag_diff = _build_dag_diff(parent_version.dag_definition, dag_dict)
+
     version = DAGVersion(
         project_id=project_id,
         version_number=next_version,
+        name=name,
+        description=description,
+        parent_version_id=parent_version_id,
         dag_definition=dag_dict,
+        dag_diff=dag_diff,
         is_current=set_current,
     )
     db.add(version)
+    try:
+        db.commit()
+    except IntegrityError as error:
+        db.rollback()
+        raise ValueError("Concurrent save conflict; please retry") from error
+    db.refresh(version)
+    return version
+
+
+def update_version(
+    db: Session,
+    version: DAGVersion,
+    dag_definition: DAGDefinition,
+    name: str | None = None,
+    description: str | None = None,
+) -> DAGVersion:
+    """Update an existing DAG version in place.
+
+    Note: `parent_version_id` is intentionally immutable. `dag_diff` always
+    represents delta from the original parent to the latest state.
+    """
+    dag_dict: dict[str, Any] = dag_definition.model_dump(mode="json")
+
+    version.dag_definition = dag_dict
+    if name is not None:
+        version.name = name
+    if description is not None:
+        version.description = description
+
+    if version.parent_version_id:
+        parent = db.get(DAGVersion, version.parent_version_id)
+        if parent:
+            version.dag_diff = _build_dag_diff(parent.dag_definition, dag_dict)
+        else:
+            logger.warning(
+                "Missing parent version while updating DAG version",
+                extra={"version_id": version.id, "parent_version_id": version.parent_version_id},
+            )
+            version.dag_diff = None
+    else:
+        version.dag_diff = None
+
     db.commit()
     db.refresh(version)
     return version
@@ -150,7 +213,11 @@ def set_current_version(db: Session, version: DAGVersion) -> DAGVersion:
     _unset_current_versions(db, version.project_id)
 
     version.is_current = True
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError as error:
+        db.rollback()
+        raise ValueError("Concurrent save conflict; please retry") from error
     db.refresh(version)
     return version
 
@@ -162,3 +229,27 @@ def _unset_current_versions(db: Session, project_id: str) -> None:
     )
     for version in db.execute(stmt).scalars().all():
         version.is_current = False
+
+
+def _build_dag_diff(previous_dag: dict[str, Any], current_dag: dict[str, Any]) -> list[dict[str, Any]] | None:
+    """Build a JSON patch diff and cap its size to avoid oversized DB payloads."""
+    try:
+        patch_ops = jsonpatch.JsonPatch.from_diff(previous_dag, current_dag).patch
+    except Exception:
+        logger.exception("Failed computing DAG diff")
+        return None
+
+    try:
+        patch_size = len(json.dumps(patch_ops, separators=(",", ":")).encode("utf-8"))
+    except Exception:
+        logger.exception("Failed measuring DAG diff size")
+        return None
+
+    if patch_size > MAX_DAG_DIFF_BYTES:
+        logger.warning(
+            "Skipping oversized DAG diff",
+            extra={"diff_bytes": patch_size, "max_bytes": MAX_DAG_DIFF_BYTES},
+        )
+        return None
+
+    return patch_ops

--- a/backend/app/db/crud.py
+++ b/backend/app/db/crud.py
@@ -139,6 +139,7 @@ def create_version(
     # If setting as current, unset current flag from other versions
     if set_current:
         _unset_current_versions(db, project_id)
+        db.flush()  # Flush to ensure is_current=False is persisted before creating new current
 
     # Serialize DAGDefinition to dict
     dag_dict: dict[str, Any] = dag_definition.model_dump(mode="json")
@@ -211,6 +212,7 @@ def set_current_version(db: Session, version: DAGVersion) -> DAGVersion:
     """Set a version as the current version."""
     # Unset current flag from other versions
     _unset_current_versions(db, version.project_id)
+    db.flush()  # Flush to ensure is_current=False is persisted before setting new current
 
     version.is_current = True
     try:

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -73,7 +73,13 @@ class DAGVersion(Base):
         String(36), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False
     )
     version_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    description: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+    parent_version_id: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("dag_versions.id", ondelete="SET NULL"), nullable=True
+    )
     dag_definition: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    dag_diff: Mapped[list[dict[str, Any]] | None] = mapped_column(JSON, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime, server_default=func.now(), nullable=False
     )

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Index, Integer, String, Text, func
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, Integer, String, Text, func, text
 from sqlalchemy.dialects.sqlite import JSON
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -73,8 +73,8 @@ class DAGVersion(Base):
             "uq_dag_versions_one_current_per_project",
             "project_id",
             unique=True,
-            sqlite_where="is_current = 1",
-            postgresql_where="is_current = true",
+            sqlite_where=text("is_current = 1"),
+            postgresql_where=text("is_current = true"),
         ),
     )
 

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -67,6 +67,16 @@ class DAGVersion(Base):
     """DAG version model for storing versioned DAG definitions."""
 
     __tablename__ = "dag_versions"
+    __table_args__ = (
+        Index("ix_dag_versions_parent_version_id", "parent_version_id"),
+        Index(
+            "uq_dag_versions_one_current_per_project",
+            "project_id",
+            unique=True,
+            sqlite_where="is_current = 1",
+            postgresql_where="is_current = true",
+        ),
+    )
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=generate_uuid)
     project_id: Mapped[str] = mapped_column(

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "PyJWT[crypto]>=2.8.0",
     "cryptography>=42.0.0",
     "slowapi>=0.1.9",
+    "jsonpatch>=1.33",
 ]
 
 [project.optional-dependencies]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,6 +23,7 @@ simpleeval>=0.9.13
 # Database
 sqlalchemy>=2.0.0
 alembic>=1.13.0
+jsonpatch>=1.33
 
 # Dev
 pytest>=8.0.0

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -215,15 +215,19 @@ source = { editable = "." }
 dependencies = [
     { name = "alembic" },
     { name = "clerk-backend-api" },
+    { name = "cryptography" },
     { name = "fastapi" },
+    { name = "jsonpatch" },
     { name = "numpy" },
     { name = "pandas" },
     { name = "psycopg2-binary" },
     { name = "pyarrow" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "scipy" },
     { name = "simpleeval" },
+    { name = "slowapi" },
     { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -241,8 +245,10 @@ dev = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.13.0" },
     { name = "clerk-backend-api", specifier = ">=4.2.0" },
+    { name = "cryptography", specifier = ">=42.0.0" },
     { name = "fastapi", specifier = ">=0.109.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.26.0" },
+    { name = "jsonpatch", specifier = ">=1.33" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
     { name = "numpy", specifier = ">=1.26.0" },
     { name = "pandas", specifier = ">=2.2.0" },
@@ -250,15 +256,29 @@ requires-dist = [
     { name = "pyarrow", specifier = ">=15.0.0" },
     { name = "pydantic", specifier = ">=2.5.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.2.0" },
     { name = "scipy", specifier = ">=1.12.0" },
     { name = "simpleeval", specifier = ">=0.9.13" },
+    { name = "slowapi", specifier = ">=0.1.9" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.27.0" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
 
 [[package]]
 name = "fastapi"
@@ -414,6 +434,27 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonpatch"
+version = "1.33"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonpointer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/78/18813351fe5d63acad16aec57f94ec2b70a09e53ca98145589e185423873/jsonpatch-1.33.tar.gz", hash = "sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c", size = 21699, upload-time = "2023-06-26T12:07:29.144Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/07/02e16ed01e04a374e644b575638ec7987ae846d25ad97bcc9945a3ee4b0e/jsonpatch-1.33-py2.py3-none-any.whl", hash = "sha256:0ae28c0cd062bbd8b8ecc26d7d164fbbea9652a1a3693f3b956c1eae5145dade", size = 12898, upload-time = "2023-06-16T21:01:28.466Z" },
+]
+
+[[package]]
+name = "jsonpointer"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/0a/eebeb1fa92507ea94016a2a790b93c2ae41a7e18778f85471dc54475ed25/jsonpointer-3.0.0.tar.gz", hash = "sha256:2b2d729f2091522d61c3b31f82e11870f60b68f43fbc705cb76bf4b832af59ef", size = 9114, upload-time = "2024-06-10T19:24:42.462Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/92/5e77f98553e9e75130c78900d000368476aed74276eb8ae8796f65f00918/jsonpointer-3.0.0-py2.py3-none-any.whl", hash = "sha256:13e088adc14fca8b6aa8177c044e12701e6ad4b28ff10e65f2267a90109c9942", size = 7595, upload-time = "2024-06-10T19:24:40.698Z" },
+]
+
+[[package]]
 name = "librt"
 version = "0.7.8"
 source = { registry = "https://pypi.org/simple" }
@@ -474,6 +515,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/f0/07fb6ab5c39a4ca9af3e37554f9d42f25c464829254d72e4ebbd81da351c/librt-0.7.8-cp314-cp314t-win32.whl", hash = "sha256:171ca3a0a06c643bd0a2f62a8944e1902c94aa8e5da4db1ea9a8daf872685365", size = 41173, upload-time = "2026-01-14T12:55:59.315Z" },
     { url = "https://files.pythonhosted.org/packages/24/d4/7e4be20993dc6a782639625bd2f97f3c66125c7aa80c82426956811cfccf/librt-0.7.8-cp314-cp314t-win_amd64.whl", hash = "sha256:445b7304145e24c60288a2f172b5ce2ca35c0f81605f5299f3fa567e189d2e32", size = 47668, upload-time = "2026-01-14T12:56:00.261Z" },
     { url = "https://files.pythonhosted.org/packages/fc/85/69f92b2a7b3c0f88ffe107c86b952b397004b5b8ea5a81da3d9c04c04422/librt-0.7.8-cp314-cp314t-win_arm64.whl", hash = "sha256:8766ece9de08527deabcd7cb1b4f1a967a385d26e33e536d6d8913db6ef74f06", size = 40550, upload-time = "2026-01-14T12:56:01.542Z" },
+]
+
+[[package]]
+name = "limits"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104, upload-time = "2026-02-05T07:17:35.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954, upload-time = "2026-02-05T07:17:34.425Z" },
 ]
 
 [[package]]
@@ -1025,6 +1080,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
 ]
 
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
 [[package]]
 name = "pytest"
 version = "9.0.2"
@@ -1252,6 +1312,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "slowapi"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "limits" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/99/adfc7f94ca024736f061257d39118e1542bade7a52e86415a4c4ae92d8ff/slowapi-0.1.9.tar.gz", hash = "sha256:639192d0f1ca01b1c6d95bf6c71d794c3a9ee189855337b4821f7f457dddad77", size = 14028, upload-time = "2024-02-05T12:11:52.13Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/bb/f71c4b7d7e7eb3fc1e8c0458a8979b912f40b58002b9fbf37729b8cb464b/slowapi-0.1.9-py3-none-any.whl", hash = "sha256:cfad116cfb84ad9d763ee155c1e5c5cbf00b0d47399a769b227865f5df576e36", size = 14670, upload-time = "2024-02-05T12:11:50.898Z" },
 ]
 
 [[package]]
@@ -1545,4 +1617,67 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
     { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/37/ae31f40bec90de2f88d9597d0b5281e23ffe85b893a47ca5d9c05c63a4f6/wrapt-2.1.1.tar.gz", hash = "sha256:5fdcb09bf6db023d88f312bd0767594b414655d58090fc1c46b3414415f67fac", size = 81329, upload-time = "2026-02-03T02:12:13.786Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/a8/9254e4da74b30a105935197015b18b31b7a298bf046e67d8952ef74967bd/wrapt-2.1.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6c366434a7fb914c7a5de508ed735ef9c133367114e1a7cb91dfb5cd806a1549", size = 60554, upload-time = "2026-02-03T02:11:13.038Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/a1/378579880cc7af226354054a2c255f69615b379d8adad482bfe2f22a0dc2/wrapt-2.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5d6a2068bd2e1e19e5a317c8c0b288267eec4e7347c36bc68a6e378a39f19ee7", size = 61491, upload-time = "2026-02-03T02:12:56.077Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/72/957b51c56acca35701665878ad31626182199fc4afecfe67dea072210f95/wrapt-2.1.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:891ab4713419217b2aed7dd106c9200f64e6a82226775a0d2ebd6bef2ebd1747", size = 113949, upload-time = "2026-02-03T02:11:04.516Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/74/36bbebb4a3d2ae9c3e6929639721f8606cd0710a82a777c371aa69e36504/wrapt-2.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c8ef36a0df38d2dc9d907f6617f89e113c5892e0a35f58f45f75901af0ce7d81", size = 115989, upload-time = "2026-02-03T02:12:19.398Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/0d/f1177245a083c7be284bc90bddfe5aece32cdd5b858049cb69ce001a0e8d/wrapt-2.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:76e9af3ebd86f19973143d4d592cbf3e970cf3f66ddee30b16278c26ae34b8ab", size = 115242, upload-time = "2026-02-03T02:11:08.111Z" },
+    { url = "https://files.pythonhosted.org/packages/62/3e/3b7cf5da27e59df61b1eae2d07dd03ff5d6f75b5408d694873cca7a8e33c/wrapt-2.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ff562067485ebdeaef2fa3fe9b1876bc4e7b73762e0a01406ad81e2076edcebf", size = 113676, upload-time = "2026-02-03T02:12:41.026Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/65/8248d3912c705f2c66f81cb97c77436f37abcbedb16d633b5ab0d795d8cd/wrapt-2.1.1-cp311-cp311-win32.whl", hash = "sha256:9e60a30aa0909435ec4ea2a3c53e8e1b50ac9f640c0e9fe3f21fd248a22f06c5", size = 57863, upload-time = "2026-02-03T02:12:18.112Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/31/d29310ab335f71f00c50466153b3dc985aaf4a9fc03263e543e136859541/wrapt-2.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:7d79954f51fcf84e5ec4878ab4aea32610d70145c5bbc84b3370eabfb1e096c2", size = 60224, upload-time = "2026-02-03T02:12:29.289Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/90/a6ec319affa6e2894962a0cb9d73c67f88af1a726d15314bfb5c88b8a08d/wrapt-2.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:d3ffc6b0efe79e08fd947605fd598515aebefe45e50432dc3b5cd437df8b1ada", size = 58643, upload-time = "2026-02-03T02:12:43.022Z" },
+    { url = "https://files.pythonhosted.org/packages/df/cb/4d5255d19bbd12be7f8ee2c1fb4269dddec9cef777ef17174d357468efaa/wrapt-2.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ab8e3793b239db021a18782a5823fcdea63b9fe75d0e340957f5828ef55fcc02", size = 61143, upload-time = "2026-02-03T02:11:46.313Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/07/7ed02daa35542023464e3c8b7cb937fa61f6c61c0361ecf8f5fecf8ad8da/wrapt-2.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7c0300007836373d1c2df105b40777986accb738053a92fe09b615a7a4547e9f", size = 61740, upload-time = "2026-02-03T02:12:51.966Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/60/a237a4e4a36f6d966061ccc9b017627d448161b19e0a3ab80a7c7c97f859/wrapt-2.1.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2b27c070fd1132ab23957bcd4ee3ba707a91e653a9268dc1afbd39b77b2799f7", size = 121327, upload-time = "2026-02-03T02:11:06.796Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/fe/9139058a3daa8818fc67e6460a2340e8bbcf3aef8b15d0301338bbe181ca/wrapt-2.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b0e36d845e8b6f50949b6b65fc6cd279f47a1944582ed4ec8258cd136d89a64", size = 122903, upload-time = "2026-02-03T02:12:48.657Z" },
+    { url = "https://files.pythonhosted.org/packages/91/10/b8479202b4164649675846a531763531f0a6608339558b5a0a718fc49a8d/wrapt-2.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4aeea04a9889370fcfb1ef828c4cc583f36a875061505cd6cd9ba24d8b43cc36", size = 121333, upload-time = "2026-02-03T02:11:32.148Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/75/75fc793b791d79444aca2c03ccde64e8b99eda321b003f267d570b7b0985/wrapt-2.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d88b46bb0dce9f74b6817bc1758ff2125e1ca9e1377d62ea35b6896142ab6825", size = 120458, upload-time = "2026-02-03T02:11:16.039Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8f/c3f30d511082ca6d947c405f9d8f6c8eaf83cfde527c439ec2c9a30eb5ea/wrapt-2.1.1-cp312-cp312-win32.whl", hash = "sha256:63decff76ca685b5c557082dfbea865f3f5f6d45766a89bff8dc61d336348833", size = 58086, upload-time = "2026-02-03T02:12:35.041Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/c8/37625b643eea2849f10c3b90f69c7462faa4134448d4443234adaf122ae5/wrapt-2.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:b828235d26c1e35aca4107039802ae4b1411be0fe0367dd5b7e4d90e562fcbcd", size = 60328, upload-time = "2026-02-03T02:12:45.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/79/56242f07572d5682ba8065a9d4d9c2218313f576e3c3471873c2a5355ffd/wrapt-2.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:75128507413a9f1bcbe2db88fd18fbdbf80f264b82fa33a6996cdeaf01c52352", size = 58722, upload-time = "2026-02-03T02:12:27.949Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ca/3cf290212855b19af9fcc41b725b5620b32f470d6aad970c2593500817eb/wrapt-2.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ce9646e17fa7c3e2e7a87e696c7de66512c2b4f789a8db95c613588985a2e139", size = 61150, upload-time = "2026-02-03T02:12:50.575Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/33/5b8f89a82a9859ce82da4870c799ad11ce15648b6e1c820fec3e23f4a19f/wrapt-2.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:428cfc801925454395aa468ba7ddb3ed63dc0d881df7b81626cdd433b4e2b11b", size = 61743, upload-time = "2026-02-03T02:11:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2f/60c51304fbdf47ce992d9eefa61fbd2c0e64feee60aaa439baf42ea6f40b/wrapt-2.1.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5797f65e4d58065a49088c3b32af5410751cd485e83ba89e5a45e2aa8905af98", size = 121341, upload-time = "2026-02-03T02:11:20.461Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/03/ce5256e66dd94e521ad5e753c78185c01b6eddbed3147be541f4d38c0cb7/wrapt-2.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5a2db44a71202c5ae4bb5f27c6d3afbc5b23053f2e7e78aa29704541b5dad789", size = 122947, upload-time = "2026-02-03T02:11:33.596Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ae/50ca8854b81b946a11a36fcd6ead32336e6db2c14b6e4a8b092b80741178/wrapt-2.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8d5350c3590af09c1703dd60ec78a7370c0186e11eaafb9dda025a30eee6492d", size = 121370, upload-time = "2026-02-03T02:11:09.886Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d9/d6a7c654e0043319b4cc137a4caaf7aa16b46b51ee8df98d1060254705b7/wrapt-2.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2d9b076411bed964e752c01b49fd224cc385f3a96f520c797d38412d70d08359", size = 120465, upload-time = "2026-02-03T02:11:37.592Z" },
+    { url = "https://files.pythonhosted.org/packages/55/90/65be41e40845d951f714b5a77e84f377a3787b1e8eee6555a680da6d0db5/wrapt-2.1.1-cp313-cp313-win32.whl", hash = "sha256:0bb7207130ce6486727baa85373503bf3334cc28016f6928a0fa7e19d7ecdc06", size = 58090, upload-time = "2026-02-03T02:12:53.342Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/66/6a09e0294c4fc8c26028a03a15191721c9271672467cc33e6617ee0d91d2/wrapt-2.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:cbfee35c711046b15147b0ae7db9b976f01c9520e6636d992cd9e69e5e2b03b1", size = 60341, upload-time = "2026-02-03T02:12:36.384Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f0/20ceb8b701e9a71555c87a5ddecbed76ec16742cf1e4b87bbaf26735f998/wrapt-2.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:7d2756061022aebbf57ba14af9c16e8044e055c22d38de7bf40d92b565ecd2b0", size = 58731, upload-time = "2026-02-03T02:12:01.328Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b4/fe95beb8946700b3db371f6ce25115217e7075ca063663b8cca2888ba55c/wrapt-2.1.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:4814a3e58bc6971e46baa910ecee69699110a2bf06c201e24277c65115a20c20", size = 62969, upload-time = "2026-02-03T02:11:51.245Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/89/477b0bdc784e3299edf69c279697372b8bd4c31d9c6966eae405442899df/wrapt-2.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:106c5123232ab9b9f4903692e1fa0bdc231510098f04c13c3081f8ad71c3d612", size = 63606, upload-time = "2026-02-03T02:12:02.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/55/9d0c1269ab76de87715b3b905df54dd25d55bbffd0b98696893eb613469f/wrapt-2.1.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1a40b83ff2535e6e56f190aff123821eea89a24c589f7af33413b9c19eb2c738", size = 152536, upload-time = "2026-02-03T02:11:24.492Z" },
+    { url = "https://files.pythonhosted.org/packages/44/18/2004766030462f79ad86efaa62000b5e39b1ff001dcce86650e1625f40ae/wrapt-2.1.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:789cea26e740d71cf1882e3a42bb29052bc4ada15770c90072cb47bf73fb3dbf", size = 158697, upload-time = "2026-02-03T02:12:32.214Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/bb/0a880fa0f35e94ee843df4ee4dd52a699c9263f36881311cfb412c09c3e5/wrapt-2.1.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ba49c14222d5e5c0ee394495a8655e991dc06cbca5398153aefa5ac08cd6ccd7", size = 155563, upload-time = "2026-02-03T02:11:49.737Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ff/cd1b7c4846c8678fac359a6eb975dc7ab5bd606030adb22acc8b4a9f53f1/wrapt-2.1.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:ac8cda531fe55be838a17c62c806824472bb962b3afa47ecbd59b27b78496f4e", size = 150161, upload-time = "2026-02-03T02:12:33.613Z" },
+    { url = "https://files.pythonhosted.org/packages/38/ec/67c90a7082f452964b4621e4890e9a490f1add23cdeb7483cc1706743291/wrapt-2.1.1-cp313-cp313t-win32.whl", hash = "sha256:b8af75fe20d381dd5bcc9db2e86a86d7fcfbf615383a7147b85da97c1182225b", size = 59783, upload-time = "2026-02-03T02:11:39.863Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/08/466afe4855847d8febdfa2c57c87e991fc5820afbdef01a273683dfd15a0/wrapt-2.1.1-cp313-cp313t-win_amd64.whl", hash = "sha256:45c5631c9b6c792b78be2d7352129f776dd72c605be2c3a4e9be346be8376d83", size = 63082, upload-time = "2026-02-03T02:12:09.075Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/62/60b629463c28b15b1eeadb3a0691e17568622b12aa5bfa7ebe9b514bfbeb/wrapt-2.1.1-cp313-cp313t-win_arm64.whl", hash = "sha256:da815b9263947ac98d088b6414ac83507809a1d385e4632d9489867228d6d81c", size = 60251, upload-time = "2026-02-03T02:11:21.794Z" },
+    { url = "https://files.pythonhosted.org/packages/95/a0/1c2396e272f91efe6b16a6a8bce7ad53856c8f9ae4f34ceaa711d63ec9e1/wrapt-2.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9aa1765054245bb01a37f615503290d4e207e3fd59226e78341afb587e9c1236", size = 61311, upload-time = "2026-02-03T02:12:44.41Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/9a/d2faba7e61072a7507b5722db63562fdb22f5a24e237d460d18755627f15/wrapt-2.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:feff14b63a6d86c1eee33a57f77573649f2550935981625be7ff3cb7342efe05", size = 61805, upload-time = "2026-02-03T02:11:59.905Z" },
+    { url = "https://files.pythonhosted.org/packages/db/56/073989deb4b5d7d6e7ea424476a4ae4bda02140f2dbeaafb14ba4864dd60/wrapt-2.1.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:81fc5f22d5fcfdbabde96bb3f5379b9f4476d05c6d524d7259dc5dfb501d3281", size = 120308, upload-time = "2026-02-03T02:12:04.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b6/84f37261295e38167a29eb82affaf1dc15948dc416925fe2091beee8e4ac/wrapt-2.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:951b228ecf66def855d22e006ab9a1fc12535111ae7db2ec576c728f8ddb39e8", size = 122688, upload-time = "2026-02-03T02:11:23.148Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/80/32db2eec6671f80c65b7ff175be61bc73d7f5223f6910b0c921bbc4bd11c/wrapt-2.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ddf582a95641b9a8c8bd643e83f34ecbbfe1b68bc3850093605e469ab680ae3", size = 121115, upload-time = "2026-02-03T02:12:39.068Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ef/dcd00383df0cd696614127902153bf067971a5aabcd3c9dcb2d8ef354b2a/wrapt-2.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fc5c500966bf48913f795f1984704e6d452ba2414207b15e1f8c339a059d5b16", size = 119484, upload-time = "2026-02-03T02:11:48.419Z" },
+    { url = "https://files.pythonhosted.org/packages/76/29/0630280cdd2bd8f86f35cb6854abee1c9d6d1a28a0c6b6417cd15d378325/wrapt-2.1.1-cp314-cp314-win32.whl", hash = "sha256:4aa4baadb1f94b71151b8e44a0c044f6af37396c3b8bcd474b78b49e2130a23b", size = 58514, upload-time = "2026-02-03T02:11:58.616Z" },
+    { url = "https://files.pythonhosted.org/packages/db/19/5bed84f9089ed2065f6aeda5dfc4f043743f642bc871454b261c3d7d322b/wrapt-2.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:860e9d3fd81816a9f4e40812f28be4439ab01f260603c749d14be3c0a1170d19", size = 60763, upload-time = "2026-02-03T02:12:24.553Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/cb/b967f2f9669e4249b4fe82e630d2a01bc6b9e362b9b12ed91bbe23ae8df4/wrapt-2.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:3c59e103017a2c1ea0ddf589cbefd63f91081d7ce9d491d69ff2512bb1157e23", size = 59051, upload-time = "2026-02-03T02:11:29.602Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/19/6fed62be29f97eb8a56aff236c3f960a4b4a86e8379dc7046a8005901a97/wrapt-2.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:9fa7c7e1bee9278fc4f5dd8275bc8d25493281a8ec6c61959e37cc46acf02007", size = 63059, upload-time = "2026-02-03T02:12:06.368Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1c/b757fd0adb53d91547ed8fad76ba14a5932d83dde4c994846a2804596378/wrapt-2.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:39c35e12e8215628984248bd9c8897ce0a474be2a773db207eb93414219d8469", size = 63618, upload-time = "2026-02-03T02:12:23.197Z" },
+    { url = "https://files.pythonhosted.org/packages/10/fe/e5ae17b1480957c7988d991b93df9f2425fc51f128cf88144d6a18d0eb12/wrapt-2.1.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:94ded4540cac9125eaa8ddf5f651a7ec0da6f5b9f248fe0347b597098f8ec14c", size = 152544, upload-time = "2026-02-03T02:11:43.915Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/cc/99aed210c6b547b8a6e4cb9d1425e4466727158a6aeb833aa7997e9e08dd/wrapt-2.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:da0af328373f97ed9bdfea24549ac1b944096a5a71b30e41c9b8b53ab3eec04a", size = 158700, upload-time = "2026-02-03T02:12:30.684Z" },
+    { url = "https://files.pythonhosted.org/packages/81/0e/d442f745f4957944d5f8ad38bc3a96620bfff3562533b87e486e979f3d99/wrapt-2.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4ad839b55f0bf235f8e337ce060572d7a06592592f600f3a3029168e838469d3", size = 155561, upload-time = "2026-02-03T02:11:28.164Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ac/9891816280e0018c48f8dfd61b136af7b0dcb4a088895db2531acde5631b/wrapt-2.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0d89c49356e5e2a50fa86b40e0510082abcd0530f926cbd71cf25bee6b9d82d7", size = 150188, upload-time = "2026-02-03T02:11:57.053Z" },
+    { url = "https://files.pythonhosted.org/packages/24/98/e2f273b6d70d41f98d0739aa9a269d0b633684a5fb17b9229709375748d4/wrapt-2.1.1-cp314-cp314t-win32.whl", hash = "sha256:f4c7dd22cf7f36aafe772f3d88656559205c3af1b7900adfccb70edeb0d2abc4", size = 60425, upload-time = "2026-02-03T02:11:35.007Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/06/b500bfc38a4f82d89f34a13069e748c82c5430d365d9e6b75afb3ab74457/wrapt-2.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f76bc12c583ab01e73ba0ea585465a41e48d968f6d1311b4daec4f8654e356e3", size = 63855, upload-time = "2026-02-03T02:12:15.47Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/cc/5f6193c32166faee1d2a613f278608e6f3b95b96589d020f0088459c46c9/wrapt-2.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:7ea74fc0bec172f1ae5f3505b6655c541786a5cabe4bbc0d9723a56ac32eb9b9", size = 60443, upload-time = "2026-02-03T02:11:30.869Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/da/5a086bf4c22a41995312db104ec2ffeee2cf6accca9faaee5315c790377d/wrapt-2.1.1-py3-none-any.whl", hash = "sha256:3b0f4629eb954394a3d7c7a1c8cca25f0b07cefe6aa8545e862e9778152de5b7", size = 43886, upload-time = "2026-02-03T02:11:45.048Z" },
 ]

--- a/frontend/src/components/ProjectSidebar/VersionItem.tsx
+++ b/frontend/src/components/ProjectSidebar/VersionItem.tsx
@@ -63,7 +63,9 @@ export function VersionItem({ projectId, version, isSelected }: VersionItemProps
       {!version.is_current && <span className="w-1.5 flex-shrink-0" />}
 
       {/* Version info */}
-      <span className="font-medium">v{version.version_number}</span>
+      <span className="font-medium">
+        {version.name?.trim() ? version.name : `v${version.version_number}`}
+      </span>
       <span className="text-xs text-gray-400 flex-1 truncate">
         {formatRelativeTime(version.created_at)}
       </span>

--- a/frontend/src/components/Toolbar/Toolbar.tsx
+++ b/frontend/src/components/Toolbar/Toolbar.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { CheckCircle, Download, Upload, Trash2, Save } from 'lucide-react';
+import { CheckCircle, Download, Upload, Trash2, Save, ArrowUpRight } from 'lucide-react';
 import { SignedIn, SignedOut, SignInButton, UserButton } from '@clerk/clerk-react';
 import { useDAGStore, selectActiveMainTab } from '../../stores/dagStore';
 import { useProjectStore } from '../../stores/projectStore';
@@ -15,6 +15,11 @@ export const Toolbar: React.FC = () => {
   const [isValidating, setIsValidating] = useState(false);
   const [isPreviewing, setIsPreviewing] = useState(false);
   const [isNewProjectDialogOpen, setIsNewProjectDialogOpen] = useState(false);
+  const [isSaveAsNewDialogOpen, setIsSaveAsNewDialogOpen] = useState(false);
+  const [showStructuralChangeDialog, setShowStructuralChangeDialog] = useState(false);
+  const [versionName, setVersionName] = useState('');
+  const [versionDescription, setVersionDescription] = useState('');
+  const [versionNameError, setVersionNameError] = useState<string | null>(null);
   const { addToast } = useToast();
 
   const {
@@ -28,16 +33,18 @@ export const Toolbar: React.FC = () => {
     setLastValidationResult,
   } = useDAGStore();
 
-  const saveVersion = useProjectStore((s) => s.saveVersion);
+  const saveCurrentVersion = useProjectStore((s) => s.saveCurrentVersion);
+  const saveNewVersion = useProjectStore((s) => s.saveNewVersion);
   const isSaving = useProjectStore((s) => s.isSaving);
   const hasUnsavedChanges = useProjectStore((s) => s.hasUnsavedChanges);
+  const hasStructuralChanges = useProjectStore((s) => s.hasStructuralChanges);
   const currentProjectId = useProjectStore((s) => s.currentProjectId);
+  const currentVersionId = useProjectStore((s) => s.currentVersionId);
 
   const activeMainTab = useDAGStore(selectActiveMainTab);
   const isDagTab = activeMainTab === 'dag';
 
-  // Save version
-  const handleSave = async () => {
+  const handleSaveCurrent = async () => {
     // If no project is selected, open the New Project dialog
     if (!currentProjectId) {
       setIsNewProjectDialogOpen(true);
@@ -45,10 +52,57 @@ export const Toolbar: React.FC = () => {
     }
 
     try {
-      await saveVersion();
+      await saveCurrentVersion();
       addToast('success', 'Project saved successfully');
     } catch (error) {
       addToast('error', 'Failed to save project');
+      console.error(error);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!currentProjectId) {
+      setIsNewProjectDialogOpen(true);
+      return;
+    }
+
+    if (!currentVersionId) {
+      handleSaveAsNew();
+      return;
+    }
+
+    if (hasStructuralChanges()) {
+      setShowStructuralChangeDialog(true);
+      return;
+    }
+
+    await handleSaveCurrent();
+  };
+
+  const handleSaveAsNew = async () => {
+    if (!currentProjectId) {
+      setIsNewProjectDialogOpen(true);
+      return;
+    }
+    setVersionName('');
+    setVersionDescription('');
+    setVersionNameError(null);
+    setIsSaveAsNewDialogOpen(true);
+  };
+
+  const handleSubmitSaveAsNew = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!versionName.trim()) {
+      setVersionNameError('Version name is required');
+      return;
+    }
+
+    try {
+      await saveNewVersion(versionName.trim(), versionDescription.trim() || undefined);
+      setIsSaveAsNewDialogOpen(false);
+      addToast('success', 'New version created');
+    } catch (error) {
+      addToast('error', 'Failed to create new version');
       console.error(error);
     }
   };
@@ -174,6 +228,140 @@ export const Toolbar: React.FC = () => {
         open={isNewProjectDialogOpen}
         onClose={() => setIsNewProjectDialogOpen(false)}
       />
+      {isSaveAsNewDialogOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div
+            className="absolute inset-0 bg-black/50"
+            onClick={() => setIsSaveAsNewDialogOpen(false)}
+          />
+          <div className="relative bg-white rounded-lg shadow-xl w-full max-w-md mx-4">
+            <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
+              <h2 className="text-lg font-semibold text-gray-900">Save New Version</h2>
+              <button
+                onClick={() => setIsSaveAsNewDialogOpen(false)}
+                className="p-1 hover:bg-gray-100 rounded text-gray-500"
+              >
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+            </div>
+            <form onSubmit={handleSubmitSaveAsNew}>
+              <div className="px-4 py-4 space-y-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Version name <span className="text-red-500">*</span>
+                  </label>
+                  <input
+                    type="text"
+                    value={versionName}
+                    onChange={(e) => {
+                      setVersionName(e.target.value);
+                      setVersionNameError(null);
+                    }}
+                    placeholder="e.g. Add income model"
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    disabled={isSaving}
+                    autoFocus
+                  />
+                  {versionNameError && (
+                    <p className="text-sm text-red-600 mt-1">{versionNameError}</p>
+                  )}
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Description <span className="text-gray-400">(optional)</span>
+                  </label>
+                  <textarea
+                    value={versionDescription}
+                    onChange={(e) => setVersionDescription(e.target.value)}
+                    placeholder="What changed in this version?"
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    rows={3}
+                    disabled={isSaving}
+                  />
+                </div>
+              </div>
+              <div className="flex items-center justify-end gap-2 px-4 py-3 border-t border-gray-200">
+                <button
+                  type="button"
+                  onClick={() => setIsSaveAsNewDialogOpen(false)}
+                  className="px-3 py-1.5 text-gray-600 hover:text-gray-800"
+                  disabled={isSaving}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  className="px-4 py-1.5 bg-green-600 text-white rounded hover:bg-green-700 disabled:bg-gray-400"
+                  disabled={isSaving}
+                >
+                  {isSaving ? 'Saving...' : 'Save New Version'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+      {showStructuralChangeDialog && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div
+            className="absolute inset-0 bg-black/50"
+            onClick={() => setShowStructuralChangeDialog(false)}
+          />
+          <div className="relative bg-white rounded-lg shadow-xl w-full max-w-md mx-4">
+            <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
+              <h2 className="text-lg font-semibold text-gray-900">Big Change Detected</h2>
+              <button
+                onClick={() => setShowStructuralChangeDialog(false)}
+                className="p-1 hover:bg-gray-100 rounded text-gray-500"
+              >
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+            </div>
+            <div className="px-4 py-4 text-sm text-gray-700">
+              You added or removed nodes/edges. This is a big change. Do you want to save
+              as a new version?
+            </div>
+            <div className="flex items-center justify-end gap-2 px-4 py-3 border-t border-gray-200">
+              <button
+                type="button"
+                onClick={async () => {
+                  setShowStructuralChangeDialog(false);
+                  await handleSaveCurrent();
+                }}
+                className="px-3 py-1.5 text-gray-600 hover:text-gray-800"
+                disabled={isSaving}
+              >
+                Save Current Version
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setShowStructuralChangeDialog(false);
+                  handleSaveAsNew();
+                }}
+                className="px-4 py-1.5 bg-green-600 text-white rounded hover:bg-green-700 disabled:bg-gray-400"
+                disabled={isSaving}
+              >
+                Save as New Version
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
       <div className="flex items-center gap-2">
         {/* DAG-specific controls - only show on DAG tab */}
         {isDagTab && (
@@ -184,22 +372,38 @@ export const Toolbar: React.FC = () => {
             {/* Divider */}
             <div className="h-6 w-px bg-gray-300" />
 
-            {/* Save Button */}
-            <button
-              onClick={handleSave}
-              disabled={isSaving || (!!currentProjectId && !hasUnsavedChanges)}
-              className="flex items-center gap-2 px-3 py-1.5 bg-green-600 text-white rounded hover:bg-green-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
-              title={
-                !currentProjectId
-                  ? 'Save as new project'
-                  : !hasUnsavedChanges
-                    ? 'No changes to save'
-                    : 'Save current version'
-              }
-            >
-              <Save size={16} />
-              <span className="text-sm font-medium">{isSaving ? 'Saving...' : 'Save'}</span>
-            </button>
+            {/* Save Split Button */}
+            <div className="flex">
+              <button
+                onClick={handleSave}
+                disabled={isSaving || (!!currentProjectId && !hasUnsavedChanges)}
+                className="flex items-center gap-2 px-3 py-1.5 bg-green-600 text-white rounded-l hover:bg-green-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+                title={
+                  !currentProjectId
+                    ? 'Save as new project'
+                    : !hasUnsavedChanges
+                      ? 'No changes to save'
+                      : 'Save current version'
+                }
+              >
+                <Save size={16} />
+                <span className="text-sm font-medium">{isSaving ? 'Saving...' : 'Save'}</span>
+              </button>
+              <button
+                onClick={handleSaveAsNew}
+                disabled={isSaving || (!!currentProjectId && !hasUnsavedChanges)}
+                className="flex items-center px-2 py-1.5 bg-green-700 text-white rounded-r hover:bg-green-800 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+                title={
+                  !currentProjectId
+                    ? 'Save as new project'
+                    : !hasUnsavedChanges
+                      ? 'No changes to save'
+                      : 'Save as new version'
+                }
+              >
+                <ArrowUpRight size={16} />
+              </button>
+            </div>
 
             {/* Validate Button */}
             <button

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -6,6 +6,8 @@ import type {
   ProjectVersion,
   CreateProjectRequest,
   UpdateProjectRequest,
+  CreateVersionRequest,
+  UpdateVersionRequest,
 } from '../types/project';
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
@@ -322,9 +324,24 @@ export const projectsApi = {
    */
   createVersion: async (
     projectId: string,
-    data: { dag_definition: DAGDefinition }
+    data: CreateVersionRequest
   ): Promise<ProjectVersion> => {
     const response = await api.post<ProjectVersion>(`/api/projects/${projectId}/versions`, data);
+    return response.data;
+  },
+
+  /**
+   * Update a DAG version in place
+   */
+  updateVersion: async (
+    projectId: string,
+    versionId: string,
+    data: UpdateVersionRequest
+  ): Promise<ProjectVersion> => {
+    const response = await api.put<ProjectVersion>(
+      `/api/projects/${projectId}/versions/${versionId}`,
+      data
+    );
     return response.data;
   },
 

--- a/frontend/src/stores/projectStore.ts
+++ b/frontend/src/stores/projectStore.ts
@@ -47,7 +47,9 @@ interface ProjectActions {
   updateProject: (projectId: string, name: string, description?: string) => Promise<void>;
 
   // Version operations
-  saveVersion: () => Promise<void>;
+  saveCurrentVersion: () => Promise<void>;
+  saveNewVersion: (name: string, description?: string) => Promise<ProjectVersion>;
+  hasStructuralChanges: () => boolean;
   fetchVersions: (projectId: string) => Promise<ProjectVersion[]>;
 
   // Dirty state
@@ -255,8 +257,50 @@ export const useProjectStore = create<ProjectState & ProjectActions>()(
       });
     },
 
-    // Save current DAG as new version
-    saveVersion: async () => {
+    // Save current DAG by updating the existing version
+    saveCurrentVersion: async () => {
+      const { currentProjectId, currentVersionId } = get();
+      if (!currentProjectId || !currentVersionId) {
+        throw new Error('No project or version selected');
+      }
+
+      set((state) => {
+        state.isSaving = true;
+      });
+
+      try {
+        const dagStore = useDAGStore.getState();
+        const dag = dagStore.exportDAG();
+
+        const version = await projectsApi.updateVersion(currentProjectId, currentVersionId, {
+          dag_definition: dag,
+        });
+
+        // Update local state
+        const dagSnapshot = JSON.stringify(dag);
+
+        set((state) => {
+          state.currentVersionId = version.id;
+          state.hasUnsavedChanges = false;
+          state.lastSavedState = dagSnapshot;
+          state.isSaving = false;
+
+          const project = state.projects.find((p) => p.id === currentProjectId);
+          if (project) {
+            project.current_version = version;
+            project.updated_at = new Date().toISOString();
+          }
+        });
+      } catch (error) {
+        set((state) => {
+          state.isSaving = false;
+        });
+        throw error;
+      }
+    },
+
+    // Save current DAG as a new version
+    saveNewVersion: async (name: string, description?: string) => {
       const { currentProjectId } = get();
       if (!currentProjectId) {
         throw new Error('No project selected');
@@ -270,7 +314,11 @@ export const useProjectStore = create<ProjectState & ProjectActions>()(
         const dagStore = useDAGStore.getState();
         const dag = dagStore.exportDAG();
 
-        const version = await projectsApi.createVersion(currentProjectId, { dag_definition: dag });
+        const version = await projectsApi.createVersion(currentProjectId, {
+          dag_definition: dag,
+          name,
+          description,
+        });
 
         // Update local state
         const dagSnapshot = JSON.stringify(dag);
@@ -281,7 +329,6 @@ export const useProjectStore = create<ProjectState & ProjectActions>()(
           state.lastSavedState = dagSnapshot;
           state.isSaving = false;
 
-          // Update the project's current version in the list
           const project = state.projects.find((p) => p.id === currentProjectId);
           if (project) {
             project.current_version = version;
@@ -289,8 +336,8 @@ export const useProjectStore = create<ProjectState & ProjectActions>()(
           }
         });
 
-        // Refresh project to get updated version list
         await get().fetchProjects();
+        return version;
       } catch (error) {
         set((state) => {
           state.isSaving = false;
@@ -343,6 +390,42 @@ export const useProjectStore = create<ProjectState & ProjectActions>()(
       const currentState = JSON.stringify(dagStore.exportDAG());
 
       return currentState !== lastSavedState;
+    },
+
+    // Check if nodes or edges were added/removed since last save
+    hasStructuralChanges: () => {
+      const { lastSavedState, currentProjectId } = get();
+      if (!currentProjectId || !lastSavedState) {
+        return false;
+      }
+
+      const dagStore = useDAGStore.getState();
+      const currentDag = dagStore.exportDAG();
+
+      let previousDag: typeof currentDag | null = null;
+      try {
+        previousDag = JSON.parse(lastSavedState);
+      } catch (error) {
+        console.error('Failed to parse last saved state:', error);
+        return true;
+      }
+
+      const prevNodeIds = new Set(previousDag.nodes.map((n) => n.id));
+      const currNodeIds = new Set(currentDag.nodes.map((n) => n.id));
+      if (prevNodeIds.size !== currNodeIds.size) return true;
+      for (const id of prevNodeIds) {
+        if (!currNodeIds.has(id)) return true;
+      }
+
+      const edgeKey = (e: { source: string; target: string }) => `${e.source}->${e.target}`;
+      const prevEdges = new Set(previousDag.edges.map(edgeKey));
+      const currEdges = new Set(currentDag.edges.map(edgeKey));
+      if (prevEdges.size !== currEdges.size) return true;
+      for (const key of prevEdges) {
+        if (!currEdges.has(key)) return true;
+      }
+
+      return false;
     },
 
     // Toggle sidebar visibility

--- a/frontend/src/stores/projectStore.ts
+++ b/frontend/src/stores/projectStore.ts
@@ -402,7 +402,7 @@ export const useProjectStore = create<ProjectState & ProjectActions>()(
       const dagStore = useDAGStore.getState();
       const currentDag = dagStore.exportDAG();
 
-      let previousDag: typeof currentDag | null = null;
+      let previousDag: typeof currentDag;
       try {
         previousDag = JSON.parse(lastSavedState);
       } catch (error) {

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -7,6 +7,9 @@ export interface ProjectVersion {
   version_number: number;
   created_at: string;
   is_current: boolean;
+  name?: string | null;
+  description?: string | null;
+  parent_version_id?: string | null;
 }
 
 export interface Project {
@@ -32,4 +35,12 @@ export interface UpdateProjectRequest {
 
 export interface CreateVersionRequest {
   dag_definition: DAGDefinition; // DAG definition
+  name?: string;
+  description?: string;
+}
+
+export interface UpdateVersionRequest {
+  dag_definition: DAGDefinition;
+  name?: string;
+  description?: string;
 }


### PR DESCRIPTION
## Summary
- split DAG save UX into `Save` (update current version in place) and `Save as new version` (split-button arrow)
- prompt on save for structural node/edge add/remove changes with explicit save mode choice
- add version metadata and lineage fields (`name`, `description`, `parent_version_id`, `dag_diff`)
- compute and persist JSON patch diffs with size guard and logging
- add `PUT /api/projects/{project_id}/versions/{version_id}` with DAG validation and current-version guard
- add DB safety for a single current version per project via partial unique index
- add index on `parent_version_id` for lineage queries

## Testing
- `cd backend && uv run pytest tests/test_projects_api.py`
- `cd frontend && npm run test:run`
