### PR TITLE
Fix model selection persistence, pre-pipeline Models tab, and local auth bypass

### DIFF
--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -46,6 +46,9 @@ async def require_auth(request: Request) -> dict:
     Raises:
         HTTPException: 401 if authentication fails
     """
+    if settings.auth_bypass:
+        return {"sub": "local-dev-user", "auth_mode": "bypass"}
+
     auth_header = request.headers.get("Authorization", "")
     if not auth_header.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Not authenticated")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -14,6 +14,7 @@ class Settings(BaseSettings):
     clerk_secret_key: str = ""
 
     # Auth - Clerk configuration
+    auth_bypass: bool = False  # Dev-only bypass for local runs
     clerk_issuer: str = ""  # Expected issuer domain, e.g., "https://clerk.data-simulator.com"
                              # Leave empty to accept any issuer (less secure, backward compatible)
 

--- a/frontend/src/components/MainTabs/PipelineView.tsx
+++ b/frontend/src/components/MainTabs/PipelineView.tsx
@@ -187,118 +187,150 @@ export const PipelineView = () => {
         );
     }
 
-    // Has DAG preview but no pipeline - show create option
-    if (hasDagPreview && !hasPipeline) {
-        return (
-            <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-slate-50 to-green-50">
-                <div className="text-center max-w-md px-8">
-                    <div className="w-20 h-20 mx-auto mb-6 rounded-2xl bg-gradient-to-br from-green-500 to-emerald-600 flex items-center justify-center shadow-lg">
-                        <PlusCircle className="w-10 h-10 text-white" />
-                    </div>
-                    <h2 className="text-2xl font-semibold text-gray-800 mb-3">
-                        Ready to Create Pipeline
-                    </h2>
-                    <p className="text-gray-500 mb-8 leading-relaxed">
-                        Your DAG preview is ready! Create a pipeline to add derived columns,
-                        apply transformations, and train ML models on your data.
-                    </p>
+    const readyToCreatePipeline = (
+        <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-slate-50 to-green-50">
+            <div className="text-center max-w-md px-8">
+                <div className="w-20 h-20 mx-auto mb-6 rounded-2xl bg-gradient-to-br from-green-500 to-emerald-600 flex items-center justify-center shadow-lg">
+                    <PlusCircle className="w-10 h-10 text-white" />
+                </div>
+                <h2 className="text-2xl font-semibold text-gray-800 mb-3">
+                    Ready to Create Pipeline
+                </h2>
+                <p className="text-gray-500 mb-8 leading-relaxed">
+                    Your DAG preview is ready! Create a pipeline to add derived columns,
+                    apply transformations, and train ML models on your data.
+                </p>
 
-                    {!showCreateModal ? (
-                        <button
-                            onClick={() => setShowCreateModal(true)}
-                            className="inline-flex items-center gap-2 bg-gradient-to-r from-green-500 to-emerald-600 text-white px-8 py-3 rounded-xl font-medium hover:from-green-600 hover:to-emerald-700 transition-all shadow-lg hover:shadow-xl transform hover:-translate-y-0.5"
-                        >
-                            <PlusCircle size={20} />
-                            Create Pipeline
-                        </button>
-                    ) : (
-                        <div className="bg-white rounded-2xl shadow-2xl p-6 text-left border border-gray-100">
-                            <div className="flex items-center justify-between mb-6">
-                                <h4 className="font-semibold text-gray-800 text-lg">
-                                    New Pipeline
-                                </h4>
-                                <button
-                                    onClick={() => setShowCreateModal(false)}
-                                    className="text-gray-400 hover:text-gray-600 transition-colors"
-                                >
-                                    <X size={20} />
-                                </button>
+                {!showCreateModal ? (
+                    <button
+                        onClick={() => setShowCreateModal(true)}
+                        className="inline-flex items-center gap-2 bg-gradient-to-r from-green-500 to-emerald-600 text-white px-8 py-3 rounded-xl font-medium hover:from-green-600 hover:to-emerald-700 transition-all shadow-lg hover:shadow-xl transform hover:-translate-y-0.5"
+                    >
+                        <PlusCircle size={20} />
+                        Create Pipeline
+                    </button>
+                ) : (
+                    <div className="bg-white rounded-2xl shadow-2xl p-6 text-left border border-gray-100">
+                        <div className="flex items-center justify-between mb-6">
+                            <h4 className="font-semibold text-gray-800 text-lg">New Pipeline</h4>
+                            <button
+                                onClick={() => setShowCreateModal(false)}
+                                className="text-gray-400 hover:text-gray-600 transition-colors"
+                            >
+                                <X size={20} />
+                            </button>
+                        </div>
+
+                        <div className="space-y-5">
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-2">
+                                    Pipeline Name
+                                </label>
+                                <input
+                                    type="text"
+                                    value={pipelineName}
+                                    onChange={(e) => setPipelineName(e.target.value)}
+                                    placeholder="e.g., Income Analysis Pipeline"
+                                    className="w-full border border-gray-200 rounded-lg px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent transition-all"
+                                    autoFocus
+                                />
                             </div>
 
-                            <div className="space-y-5">
+                            <div className="grid grid-cols-2 gap-4">
                                 <div>
                                     <label className="block text-sm font-medium text-gray-700 mb-2">
-                                        Pipeline Name
+                                        Random Seed
                                     </label>
                                     <input
-                                        type="text"
-                                        value={pipelineName}
-                                        onChange={(e) => setPipelineName(e.target.value)}
-                                        placeholder="e.g., Income Analysis Pipeline"
+                                        type="number"
+                                        value={seed}
+                                        onChange={(e) => setSeed(parseInt(e.target.value) || 42)}
                                         className="w-full border border-gray-200 rounded-lg px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent transition-all"
-                                        autoFocus
                                     />
+                                    <p className="text-xs text-gray-400 mt-1">
+                                        For reproducibility
+                                    </p>
                                 </div>
-
-                                <div className="grid grid-cols-2 gap-4">
-                                    <div>
-                                        <label className="block text-sm font-medium text-gray-700 mb-2">
-                                            Random Seed
-                                        </label>
-                                        <input
-                                            type="number"
-                                            value={seed}
-                                            onChange={(e) => setSeed(parseInt(e.target.value) || 42)}
-                                            className="w-full border border-gray-200 rounded-lg px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent transition-all"
-                                        />
-                                        <p className="text-xs text-gray-400 mt-1">
-                                            For reproducibility
-                                        </p>
-                                    </div>
-                                    <div>
-                                        <label className="block text-sm font-medium text-gray-700 mb-2">
-                                            Sample Size
-                                        </label>
-                                        <input
-                                            type="number"
-                                            value={sampleSize}
-                                            onChange={(e) =>
-                                                setSampleSize(parseInt(e.target.value) || 1000)
-                                            }
-                                            min={1}
-                                            max={100000}
-                                            className="w-full border border-gray-200 rounded-lg px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent transition-all"
-                                        />
-                                        <p className="text-xs text-gray-400 mt-1">1 - 100,000 rows</p>
-                                    </div>
-                                </div>
-
-                                <div className="flex gap-3 pt-4">
-                                    <button
-                                        onClick={() => setShowCreateModal(false)}
-                                        className="flex-1 px-4 py-3 border border-gray-200 rounded-lg text-sm font-medium text-gray-600 hover:bg-gray-50 transition-colors"
-                                    >
-                                        Cancel
-                                    </button>
-                                    <button
-                                        onClick={handleCreatePipeline}
-                                        disabled={isCreating || !pipelineName.trim()}
-                                        className="flex-1 flex items-center justify-center gap-2 bg-gradient-to-r from-green-500 to-emerald-600 text-white px-4 py-3 rounded-lg text-sm font-medium hover:from-green-600 hover:to-emerald-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all"
-                                    >
-                                        {isCreating ? (
-                                            <>
-                                                <Loader2 size={16} className="animate-spin" />
-                                                Creating...
-                                            </>
-                                        ) : (
-                                            <>
-                                                <Play size={16} />
-                                                Create Pipeline
-                                            </>
-                                        )}
-                                    </button>
+                                <div>
+                                    <label className="block text-sm font-medium text-gray-700 mb-2">
+                                        Sample Size
+                                    </label>
+                                    <input
+                                        type="number"
+                                        value={sampleSize}
+                                        onChange={(e) => setSampleSize(parseInt(e.target.value) || 1000)}
+                                        min={1}
+                                        max={100000}
+                                        className="w-full border border-gray-200 rounded-lg px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent transition-all"
+                                    />
+                                    <p className="text-xs text-gray-400 mt-1">1 - 100,000 rows</p>
                                 </div>
                             </div>
+
+                            <div className="flex gap-3 pt-4">
+                                <button
+                                    onClick={() => setShowCreateModal(false)}
+                                    className="flex-1 px-4 py-3 border border-gray-200 rounded-lg text-sm font-medium text-gray-600 hover:bg-gray-50 transition-colors"
+                                >
+                                    Cancel
+                                </button>
+                                <button
+                                    onClick={handleCreatePipeline}
+                                    disabled={isCreating || !pipelineName.trim()}
+                                    className="flex-1 flex items-center justify-center gap-2 bg-gradient-to-r from-green-500 to-emerald-600 text-white px-4 py-3 rounded-lg text-sm font-medium hover:from-green-600 hover:to-emerald-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+                                >
+                                    {isCreating ? (
+                                        <>
+                                            <Loader2 size={16} className="animate-spin" />
+                                            Creating...
+                                        </>
+                                    ) : (
+                                        <>
+                                            <Play size={16} />
+                                            Create Pipeline
+                                        </>
+                                    )}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+
+    // Has DAG preview but no pipeline - show tabs with Data/Models
+    if (hasDagPreview && !hasPipeline) {
+        return (
+            <div className="w-full h-full flex flex-col bg-gray-50">
+                <div className="flex-shrink-0 bg-white border-b border-gray-200 px-4">
+                    <div className="flex items-center justify-between">
+                        <div className="flex gap-1">
+                            {subTabs.map((tab) => (
+                                <button
+                                    key={tab.id}
+                                    onClick={() => setActiveSubTab(tab.id)}
+                                    className={`
+                                        flex items-center gap-1.5 px-4 py-3 text-sm font-medium border-b-2 transition-colors
+                                        ${activeSubTab === tab.id
+                                            ? 'border-blue-500 text-blue-600'
+                                            : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                                        }
+                                    `}
+                                >
+                                    {tab.icon}
+                                    {tab.label}
+                                </button>
+                            ))}
+                        </div>
+                    </div>
+                </div>
+
+                <div className="flex-1 overflow-hidden">
+                    {activeSubTab === 'table' && readyToCreatePipeline}
+                    {activeSubTab === 'models' && (
+                        <div className="h-full overflow-y-auto">
+                            <ModelsPanel />
                         </div>
                     )}
                 </div>

--- a/frontend/src/components/Pipeline/ModelsPanel.tsx
+++ b/frontend/src/components/Pipeline/ModelsPanel.tsx
@@ -32,83 +32,171 @@ import {
     Youtube,
     ExternalLink,
     HelpCircle,
+    Save,
+    FolderOpen,
+    Trash2,
 } from 'lucide-react';
-import { modelingApi, ModelingAPIError, type ModelTypeInfo, type FitResponse, type ModelParamValue, type ModelParameter, type ModelFitSummary, type ModelingError } from '../../api/modelingApi';
+import {
+    modelingApi,
+    ModelingAPIError,
+    type FitResponse,
+    type ModelParamValue,
+    type ModelParameter,
+    type ModelFitSummary,
+    type ModelingError,
+    type ModelParamChoiceValue,
+} from '../../api/modelingApi';
 import {
     usePipelineStore,
     selectPipelineSchema,
     selectCurrentVersionId,
 } from '../../stores/pipelineStore';
+import {
+    useModelingStore,
+    selectModelTypes,
+    selectIsLoadingModelTypes,
+    selectSelectedModel,
+    selectModelName,
+    selectModelParams,
+    selectParamErrors,
+    selectTestSize,
+    selectTargetColumn,
+    selectSelectedFeatures,
+    selectShowAdvanced,
+    selectShowInternal,
+    selectSavedConfigs,
+} from '../../stores/modelingStore';
 import { Dropdown, type DropdownOption } from '../common';
 
 // Helper to map icon names to Lucide components
-const ModelIcon = ({ name, size = 16, className = "" }: { name?: string; size?: number; className?: string }) => {
+const ModelIcon = ({
+    name,
+    size = 16,
+    className = '',
+}: {
+    name?: string;
+    size?: number;
+    className?: string;
+}) => {
     switch (name) {
-        case 'trending-up': return <TrendingUp size={size} className={className} />;
-        case 'shield': return <Shield size={size} className={className} />;
-        case 'scissors': return <Scissors size={size} className={className} />;
-        case 'git-merge': return <GitMerge size={size} className={className} />;
-        case 'git-branch': return <GitBranch size={size} className={className} />;
-        case 'trees': return <Trees size={size} className={className} />;
-        case 'zap': return <Zap size={size} className={className} />;
-        case 'flame': return <Flame size={size} className={className} />;
-        case 'users': return <Users size={size} className={className} />;
-        case 'box': return <Box size={size} className={className} />;
-        case 'minus': return <Minus size={size} className={className} />;
-        case 'wave': return <Waves size={size} className={className} />;
-        case 'target': return <TargetIcon size={size} className={className} />;
-        case 'activity': return <Activity size={size} className={className} />;
-        case 'circle': return <Circle size={size} className={className} />;
-        case 'brain': return <Brain size={size} className={className} />;
-        default: return <Brain size={size} className={className} />;
+        case 'trending-up':
+            return <TrendingUp size={size} className={className} />;
+        case 'shield':
+            return <Shield size={size} className={className} />;
+        case 'scissors':
+            return <Scissors size={size} className={className} />;
+        case 'git-merge':
+            return <GitMerge size={size} className={className} />;
+        case 'git-branch':
+            return <GitBranch size={size} className={className} />;
+        case 'trees':
+            return <Trees size={size} className={className} />;
+        case 'zap':
+            return <Zap size={size} className={className} />;
+        case 'flame':
+            return <Flame size={size} className={className} />;
+        case 'users':
+            return <Users size={size} className={className} />;
+        case 'box':
+            return <Box size={size} className={className} />;
+        case 'minus':
+            return <Minus size={size} className={className} />;
+        case 'wave':
+            return <Waves size={size} className={className} />;
+        case 'target':
+            return <TargetIcon size={size} className={className} />;
+        case 'activity':
+            return <Activity size={size} className={className} />;
+        case 'circle':
+            return <Circle size={size} className={className} />;
+        case 'brain':
+            return <Brain size={size} className={className} />;
+        default:
+            return <Brain size={size} className={className} />;
     }
+};
+
+const firstSentence = (text: string): string => {
+    const trimmed = text.trim();
+    if (!trimmed) {
+        return '';
+    }
+    const match = trimmed.match(/^.*?[.!?](?:\s|$)/);
+    return match?.[0]?.trim() ?? trimmed;
+};
+
+const getComplexityDots = (complexity?: number): number => {
+    if (!complexity || complexity <= 0) {
+        return 0;
+    }
+    return Math.max(1, Math.min(5, Math.ceil(complexity / 20)));
+};
+
+const getChoiceValue = (
+    choice: string,
+    choices: ModelParamChoiceValue[] | undefined
+): ModelParamChoiceValue => {
+    if (!choices || choices.length === 0) {
+        return choice;
+    }
+    if (choice === 'null') {
+        return null;
+    }
+    const matchedChoice = choices.find((candidate) => String(candidate) === choice);
+    return matchedChoice ?? choice;
 };
 
 export const ModelsPanel = () => {
     const schema = usePipelineStore(selectPipelineSchema);
     const currentVersionId = usePipelineStore(selectCurrentVersionId);
 
-    // Model types catalog
-    const [modelTypes, setModelTypes] = useState<ModelTypeInfo[]>([]);
-    const [isLoadingModels, setIsLoadingModels] = useState(false);
+    const modelTypes = useModelingStore(selectModelTypes);
+    const isLoadingModelTypes = useModelingStore(selectIsLoadingModelTypes);
+    const selectedModel = useModelingStore(selectSelectedModel);
+    const modelName = useModelingStore(selectModelName);
+    const modelParams = useModelingStore(selectModelParams);
+    const paramErrors = useModelingStore(selectParamErrors);
+    const testSize = useModelingStore(selectTestSize);
+    const targetColumn = useModelingStore(selectTargetColumn);
+    const selectedFeatures = useModelingStore(selectSelectedFeatures);
+    const showAdvanced = useModelingStore(selectShowAdvanced);
+    const showInternal = useModelingStore(selectShowInternal);
+    const savedConfigs = useModelingStore(selectSavedConfigs);
 
-    // Form state
-    const [selectedModel, setSelectedModel] = useState('linear_regression');
-    const [targetColumn, setTargetColumn] = useState('');
-    const [selectedFeatures, setSelectedFeatures] = useState<string[]>([]);
-    const [modelName, setModelName] = useState('');
-    const [testSize, setTestSize] = useState(0.2);
-    const [modelParams, setModelParams] = useState<Record<string, ModelParamValue>>({});
-    const [paramErrors, setParamErrors] = useState<Record<string, string>>({});
-    const [showAdvanced, setShowAdvanced] = useState(false);
-    const [showInternal, setShowInternal] = useState(false);
+    const fetchModelTypes = useModelingStore((state) => state.fetchModelTypes);
+    const setSelectedModel = useModelingStore((state) => state.setSelectedModel);
+    const setModelName = useModelingStore((state) => state.setModelName);
+    const setTestSize = useModelingStore((state) => state.setTestSize);
+    const setTargetColumn = useModelingStore((state) => state.setTargetColumn);
+    const toggleFeature = useModelingStore((state) => state.toggleFeature);
+    const setShowAdvanced = useModelingStore((state) => state.setShowAdvanced);
+    const setShowInternal = useModelingStore((state) => state.setShowInternal);
+    const updateParam = useModelingStore((state) => state.updateParam);
+    const saveCurrentConfig = useModelingStore((state) => state.saveCurrentConfig);
+    const loadConfig = useModelingStore((state) => state.loadConfig);
+    const deleteConfig = useModelingStore((state) => state.deleteConfig);
 
-    // Fit results
+    // Fit results (transient state)
     const [isFitting, setIsFitting] = useState(false);
     const [fitResult, setFitResult] = useState<FitResponse | null>(null);
     const [fitErrors, setFitErrors] = useState<ModelingError[]>([]);
     const [fittedModels, setFittedModels] = useState<ModelFitSummary[]>([]);
 
+    // Saved configuration controls (transient UI state)
+    const [configName, setConfigName] = useState('');
+    const [showSavedConfigs, setShowSavedConfigs] = useState(true);
 
-    // Load model types on mount
     useEffect(() => {
-        const loadModelTypes = async () => {
-            setIsLoadingModels(true);
-            try {
-                const models = await modelingApi.listModels();
-                setModelTypes(models);
-            } catch (error) {
-                console.error('Failed to load model types:', error);
-            } finally {
-                setIsLoadingModels(false);
-            }
-        };
-        loadModelTypes();
-    }, []);
+        fetchModelTypes();
+    }, [fetchModelTypes]);
 
     // Refresh fitted models when needed
     const refreshFits = useCallback(async () => {
-        if (!currentVersionId) return;
+        if (!currentVersionId) {
+            setFittedModels([]);
+            return;
+        }
+
         try {
             const fits = await modelingApi.listFits(currentVersionId);
             setFittedModels(fits);
@@ -121,90 +209,67 @@ export const ModelsPanel = () => {
         refreshFits();
     }, [refreshFits]);
 
-    // Reset parameters when model changes
-    useEffect(() => {
-        const model = modelTypes.find((m) => m.name === selectedModel);
-        if (model) {
-            const defaults: Record<string, ModelParamValue> = {};
-            model.parameters.forEach((p) => {
-                defaults[p.name] = p.default as ModelParamValue;
-            });
-            setModelParams(defaults);
-            setParamErrors({});
-        }
-    }, [selectedModel, modelTypes]);
-
     // Get numeric columns for features/target
     const numericColumns = schema.filter(
         (col) => col.dtype === 'float' || col.dtype === 'int'
     );
 
-    const currentModelType = modelTypes.find((m) => m.name === selectedModel);
-
-    const handleToggleFeature = (colName: string) => {
-        setSelectedFeatures((prev) =>
-            prev.includes(colName)
-                ? prev.filter((f) => f !== colName)
-                : [...prev, colName]
-        );
-    };
+    const currentModelType = modelTypes.find((model) => model.name === selectedModel);
 
     const handleUpdateParam = (name: string, value: ModelParamValue, type: string) => {
-        setModelParams(prev => ({ ...prev, [name]: value }));
+        updateParam(name, value, type);
+    };
 
-        // Basic validation
-        let error = '';
-        if (value !== '' && value !== null && value !== undefined) {
-            if (type === 'int') {
-                const n = Number(value);
-                if (!Number.isInteger(n)) {
-                    error = 'Must be an integer';
-                }
-            } else if (type === 'float') {
-                const n = Number(value);
-                if (isNaN(n)) {
-                    error = 'Must be a number';
-                }
-            }
+    const handleSaveConfig = () => {
+        const saved = saveCurrentConfig(configName);
+        if (saved) {
+            setConfigName('');
+            setShowSavedConfigs(true);
         }
-
-        setParamErrors(prev => ({ ...prev, [name]: error }));
     };
 
     const handleFit = async () => {
         if (!currentVersionId) {
-            setFitErrors([{ code: 'VALIDATION_ERROR', message: 'No active pipeline version' }]);
+            setFitErrors([
+                { code: 'VALIDATION_ERROR', message: 'Create a pipeline before fitting models' },
+            ]);
             return;
         }
 
         if (!targetColumn) {
-            setFitErrors([{
-                code: 'MISSING_TARGET',
-                message: 'Please select a target column',
-                field: 'target',
-                suggestion: 'Choose a numeric column to predict',
-            }]);
+            setFitErrors([
+                {
+                    code: 'MISSING_TARGET',
+                    message: 'Please select a target column',
+                    field: 'target',
+                    suggestion: 'Choose a numeric column to predict',
+                },
+            ]);
             return;
         }
 
         if (selectedFeatures.length === 0) {
-            setFitErrors([{
-                code: 'INVALID_FEATURES',
-                message: 'Please select at least one feature',
-                field: 'features',
-                suggestion: 'Select one or more numeric columns as input features',
-            }]);
+            setFitErrors([
+                {
+                    code: 'INVALID_FEATURES',
+                    message: 'Please select at least one feature',
+                    field: 'features',
+                    suggestion: 'Select one or more numeric columns as input features',
+                },
+            ]);
             return;
         }
 
         // Check if there are any parameter errors
-        const hasErrors = Object.values(paramErrors).some(err => !!err);
+        const hasErrors = Object.values(paramErrors).some((err) => !!err);
         if (hasErrors) {
-            setFitErrors([{
-                code: 'VALIDATION_ERROR',
-                message: 'Please fix hyperparameter errors before fitting',
-                suggestion: 'Check the highlighted parameters above',
-            }]);
+            setFitErrors([
+                {
+                    code: 'VALIDATION_ERROR',
+                    message: 'Please fix hyperparameter errors before fitting',
+                    suggestion: 'Check the highlighted parameters above',
+                },
+            ]);
             return;
         }
 
@@ -228,29 +293,39 @@ export const ModelsPanel = () => {
             });
 
             setFitResult(result);
-            refreshFits(); // Refresh the fitted models list
+            refreshFits();
         } catch (error) {
             if (error instanceof ModelingAPIError) {
                 setFitErrors(error.errors);
             } else {
-                setFitErrors([{
-                    code: 'VALIDATION_ERROR',
-                    message: error instanceof Error ? error.message : 'Failed to fit model',
-                }]);
+                setFitErrors([
+                    {
+                        code: 'VALIDATION_ERROR',
+                        message: error instanceof Error ? error.message : 'Failed to fit model',
+                    },
+                ]);
             }
         } finally {
             setIsFitting(false);
         }
     };
 
+    const modelOptions = modelTypes.map(
+        (model): DropdownOption<string> => ({
+            value: model.name,
+            label: `${model.display_name}${model.coming_soon ? ' (Coming Soon)' : ''}`,
+            icon: <ModelIcon name={model.icon} size={14} />,
+            disabled: model.coming_soon,
+            description: firstSentence(model.description),
+        })
+    );
 
-    if (!currentVersionId) {
-        return (
-            <div className="p-4 text-center text-gray-400 text-sm">
-                Create a pipeline to train models.
-            </div>
-        );
-    }
+    const isFitDisabled =
+        !currentVersionId ||
+        isFitting ||
+        !targetColumn ||
+        selectedFeatures.length === 0 ||
+        currentModelType?.coming_soon;
 
     return (
         <div className="bg-white border-l border-gray-200 w-80 flex flex-col h-full">
@@ -264,9 +339,7 @@ export const ModelsPanel = () => {
             <div className="flex-1 overflow-y-auto p-4 space-y-4">
                 {/* Model name */}
                 <div>
-                    <label className="block text-xs font-medium text-gray-600 mb-1">
-                        Model Name
-                    </label>
+                    <label className="block text-xs font-medium text-gray-600 mb-1">Model Name</label>
                     <input
                         type="text"
                         value={modelName}
@@ -278,34 +351,82 @@ export const ModelsPanel = () => {
 
                 {/* Model type selector */}
                 <div>
-                    <label className="block text-xs font-medium text-gray-600 mb-1">
-                        Model Type
-                    </label>
+                    <label className="block text-xs font-medium text-gray-600 mb-1">Model Type</label>
                     <Dropdown
-                        options={modelTypes.map((m): DropdownOption<string> => ({
-                            value: m.name,
-                            label: `${m.display_name}${m.coming_soon ? ' (Coming Soon)' : ''}`,
-                            icon: <ModelIcon name={m.icon} size={14} />,
-                            disabled: m.coming_soon,
-                        }))}
+                        options={modelOptions}
                         value={selectedModel}
                         onChange={setSelectedModel}
-                        disabled={isLoadingModels || isFitting}
+                        disabled={isLoadingModelTypes || isFitting || modelOptions.length === 0}
                         icon={<ModelIcon name={currentModelType?.icon} size={14} />}
-                        renderOption={(option, isSelected) => (
-                            <div
-                                className={`
-                                    flex items-center gap-2 px-3 py-2
-                                    ${isSelected ? 'bg-purple-50 text-purple-700' : 'text-gray-700'}
-                                    ${option.disabled ? 'opacity-50' : 'hover:bg-gray-50'}
-                                    transition-colors
-                                `}
-                            >
-                                <span className="text-purple-600">{option.icon}</span>
-                                <span className="flex-1 text-sm">{option.label}</span>
-                            </div>
-                        )}
+                        renderOption={(option, isSelected) => {
+                            const model = modelTypes.find((item) => item.name === option.value);
+                            const complexityDots = getComplexityDots(model?.complexity);
+                            const topTags = model?.tags?.slice(0, 2) ?? [];
+                            const videoCount = model?.video_links?.length ?? 0;
+
+                            return (
+                                <div
+                                    className={`
+                                        px-3 py-2 border-b border-gray-100 last:border-b-0
+                                        ${isSelected ? 'bg-purple-50 text-purple-700' : 'text-gray-700'}
+                                        ${option.disabled ? 'opacity-50' : 'hover:bg-gray-50'}
+                                        transition-colors
+                                    `}
+                                >
+                                    <div className="flex items-start gap-2">
+                                        <span className="text-purple-600 mt-0.5">{option.icon}</span>
+                                        <div className="flex-1 min-w-0">
+                                            <div className="text-sm font-medium truncate">{option.label}</div>
+                                            {option.description && (
+                                                <div className="text-[11px] text-gray-500 leading-tight mt-0.5">
+                                                    {option.description}
+                                                </div>
+                                            )}
+                                            <div className="flex flex-wrap gap-1 mt-1.5">
+                                                {model?.category && (
+                                                    <span className="text-[10px] uppercase tracking-wide bg-blue-100 text-blue-700 px-1.5 py-0.5 rounded">
+                                                        {model.category}
+                                                    </span>
+                                                )}
+                                                {topTags.map((tag) => (
+                                                    <span
+                                                        key={tag}
+                                                        className="text-[10px] bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded"
+                                                    >
+                                                        {tag}
+                                                    </span>
+                                                ))}
+                                            </div>
+                                        </div>
+                                        <div className="flex flex-col items-end gap-1 pt-0.5">
+                                            {complexityDots > 0 && (
+                                                <div className="flex gap-0.5">
+                                                    {[1, 2, 3, 4, 5].map((i) => (
+                                                        <div
+                                                            key={i}
+                                                            className={`h-1.5 w-1.5 rounded-full ${i <= complexityDots ? 'bg-purple-400' : 'bg-gray-200'}`}
+                                                        />
+                                                    ))}
+                                                </div>
+                                            )}
+                                            {videoCount > 0 && (
+                                                <div className="flex items-center gap-1 text-[10px] text-red-500">
+                                                    <Youtube size={10} />
+                                                    {videoCount}
+                                                </div>
+                                            )}
+                                        </div>
+                                    </div>
+                                </div>
+                            );
+                        }}
                     />
+                    {isLoadingModelTypes && (
+                        <p className="text-[11px] text-gray-400 mt-1">Loading model catalog...</p>
+                    )}
+                    {!isLoadingModelTypes && modelOptions.length === 0 && (
+                        <p className="text-[11px] text-red-500 mt-1">Model catalog unavailable.</p>
+                    )}
                     <div className="flex items-center gap-2 mt-1">
                         {currentModelType && (
                             <p className="text-[10px] bg-purple-100 text-purple-700 px-1.5 py-0.5 rounded font-medium uppercase tracking-wider">
@@ -319,10 +440,11 @@ export const ModelsPanel = () => {
                                     {[1, 2, 3, 4, 5].map((i) => (
                                         <div
                                             key={i}
-                                            className={`h-1 w-2 rounded-full ${i <= (currentModelType?.complexity || 0) / 20
-                                                ? 'bg-purple-400'
-                                                : 'bg-gray-200'
-                                                }`}
+                                            className={`h-1 w-2 rounded-full ${
+                                                i <= getComplexityDots(currentModelType?.complexity)
+                                                    ? 'bg-purple-400'
+                                                    : 'bg-gray-200'
+                                            }`}
                                         />
                                     ))}
                                 </div>
@@ -350,7 +472,10 @@ export const ModelsPanel = () => {
                                     <span className="text-[11px] text-gray-700 truncate pr-2">
                                         {link.title}
                                     </span>
-                                    <ExternalLink size={10} className="text-blue-400 group-hover:text-blue-600 flex-shrink-0" />
+                                    <ExternalLink
+                                        size={10}
+                                        className="text-blue-400 group-hover:text-blue-600 flex-shrink-0"
+                                    />
                                 </a>
                             ))}
                         </div>
@@ -362,207 +487,392 @@ export const ModelsPanel = () => {
                 )}
 
                 {/* Model Parameters */}
-                {currentModelType && currentModelType.parameters.length > 0 && (() => {
-                    const coreParams = currentModelType.parameters.filter(p => p.ui_group === 'core');
-                    const advancedParams = currentModelType.parameters.filter(p => p.ui_group === 'advanced' || !p.ui_group);
-                    const internalParams = currentModelType.parameters.filter(p => p.ui_group === 'internal');
+                {currentModelType && currentModelType.parameters.length > 0 &&
+                    (() => {
+                        const coreParams = currentModelType.parameters.filter(
+                            (param) => param.ui_group === 'core'
+                        );
+                        const advancedParams = currentModelType.parameters.filter(
+                            (param) => param.ui_group === 'advanced' || !param.ui_group
+                        );
+                        const internalParams = currentModelType.parameters.filter(
+                            (param) => param.ui_group === 'internal'
+                        );
 
-                    const renderParam = (p: ModelParameter) => {
-                        const hasError = !!paramErrors[p.name];
-                        const isChoice = p.type === 'choice' && p.choices && p.choices.length > 0;
-                        const isBoolean = p.type === 'boolean' || p.type === 'bool';
+                        const renderParam = (param: ModelParameter) => {
+                            const hasError = !!paramErrors[param.name];
+                            const isChoice =
+                                param.type === 'choice' &&
+                                param.choices &&
+                                param.choices.length > 0;
+                            const isBoolean = param.type === 'boolean' || param.type === 'bool';
+                            const textParamValue = modelParams[param.name];
+                            const inputValue: string | number =
+                                typeof textParamValue === 'string' ||
+                                typeof textParamValue === 'number'
+                                    ? textParamValue
+                                    : '';
+
+                            return (
+                                <div key={param.name}>
+                                    <div className="flex justify-between items-center mb-1">
+                                        <label className="text-xs font-medium text-gray-700">
+                                            {param.display_name}
+                                        </label>
+                                        <span
+                                            className={`text-[10px] font-mono italic ${
+                                                hasError ? 'text-red-500' : 'text-gray-400'
+                                            }`}
+                                        >
+                                            {param.type}
+                                        </span>
+                                    </div>
+
+                                    {isBoolean ? (
+                                        <label className="flex items-center gap-2 cursor-pointer">
+                                            <input
+                                                type="checkbox"
+                                                checked={!!modelParams[param.name]}
+                                                onChange={(e) =>
+                                                    handleUpdateParam(
+                                                        param.name,
+                                                        e.target.checked,
+                                                        param.type
+                                                    )
+                                                }
+                                                className="rounded border-gray-300 text-purple-600 focus:ring-purple-500"
+                                            />
+                                            <span className="text-xs text-gray-500">Enabled</span>
+                                        </label>
+                                    ) : isChoice ? (
+                                        <Dropdown
+                                            options={(param.choices ?? []).map(
+                                                (choice): DropdownOption<string> => ({
+                                                    value:
+                                                        choice === null
+                                                            ? 'null'
+                                                            : String(choice),
+                                                    label:
+                                                        choice === null
+                                                            ? 'None'
+                                                            : String(choice),
+                                                })
+                                            )}
+                                            value={
+                                                modelParams[param.name] === null
+                                                    ? 'null'
+                                                    : String(
+                                                          modelParams[param.name] ?? param.default
+                                                      )
+                                            }
+                                            onChange={(val) => {
+                                                handleUpdateParam(
+                                                    param.name,
+                                                    getChoiceValue(val, param.choices),
+                                                    param.type
+                                                );
+                                            }}
+                                            size="sm"
+                                            error={hasError}
+                                        />
+                                    ) : (
+                                        <>
+                                            <input
+                                                type={
+                                                    param.type === 'int' ||
+                                                    param.type === 'integer' ||
+                                                    param.type === 'float' ||
+                                                    param.type === 'number'
+                                                        ? 'number'
+                                                        : 'text'
+                                                }
+                                                step={
+                                                    param.type === 'float' ||
+                                                    param.type === 'number'
+                                                        ? '0.01'
+                                                        : '1'
+                                                }
+                                                value={
+                                                    inputValue
+                                                }
+                                                onChange={(e) => {
+                                                    const val = e.target.value;
+                                                    const isNumeric =
+                                                        param.type === 'int' ||
+                                                        param.type === 'integer' ||
+                                                        param.type === 'float' ||
+                                                        param.type === 'number';
+                                                    const parsed = isNumeric
+                                                        ? param.type === 'int' ||
+                                                          param.type === 'integer'
+                                                            ? parseInt(val, 10)
+                                                            : parseFloat(val)
+                                                        : val;
+                                                    const finalValue =
+                                                        isNumeric && Number.isNaN(parsed)
+                                                            ? val
+                                                            : (parsed as ModelParamValue);
+                                                    handleUpdateParam(
+                                                        param.name,
+                                                        finalValue,
+                                                        param.type
+                                                    );
+                                                }}
+                                                placeholder={String(param.default)}
+                                                className={`w-full border rounded-md px-2 py-1.5 text-xs focus:outline-none focus:ring-1 ${
+                                                    hasError
+                                                        ? 'border-red-300 bg-red-50 focus:ring-red-500'
+                                                        : 'border-gray-300 focus:ring-purple-500'
+                                                }`}
+                                            />
+                                            {hasError && (
+                                                <p className="text-[10px] text-red-500 mt-1 flex items-center gap-1">
+                                                    <AlertCircle size={10} />
+                                                    {paramErrors[param.name]}
+                                                </p>
+                                            )}
+                                        </>
+                                    )}
+                                    <p className="text-[10px] text-gray-400 mt-0.5 leading-tight">
+                                        {param.description}
+                                    </p>
+                                </div>
+                            );
+                        };
 
                         return (
-                            <div key={p.name}>
-                                <div className="flex justify-between items-center mb-1">
-                                    <label className="text-xs font-medium text-gray-700">
-                                        {p.display_name}
-                                    </label>
-                                    <span className={`text-[10px] font-mono italic ${hasError ? 'text-red-500' : 'text-gray-400'}`}>
-                                        {p.type}
-                                    </span>
+                            <div className="bg-gray-50 rounded-lg p-3 border border-gray-100 space-y-3">
+                                <div className="flex items-center gap-1.5 text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">
+                                    <Settings size={12} />
+                                    Hyperparameters
                                 </div>
 
-                                {isBoolean ? (
-                                    <label className="flex items-center gap-2 cursor-pointer">
-                                        <input
-                                            type="checkbox"
-                                            checked={!!modelParams[p.name]}
-                                            onChange={(e) => handleUpdateParam(p.name, e.target.checked, p.type)}
-                                            className="rounded border-gray-300 text-purple-600 focus:ring-purple-500"
-                                        />
-                                        <span className="text-xs text-gray-500">Enabled</span>
-                                    </label>
-                                ) : isChoice ? (
-                                    <Dropdown
-                                        options={(p.choices ?? []).map((choice): DropdownOption<string> => ({
-                                            value: choice === null ? 'null' : String(choice),
-                                            label: choice === null ? 'None' : String(choice),
-                                        }))}
-                                        value={modelParams[p.name] === null ? 'null' : String(modelParams[p.name] ?? p.default)}
-                                        onChange={(val) => {
-                                            handleUpdateParam(p.name, val === 'null' ? null : val, p.type);
-                                        }}
-                                        size="sm"
-                                        error={hasError}
-                                    />
-                                ) : (
-                                    <>
-                                        <input
-                                            type={p.type === 'int' || p.type === 'integer' || p.type === 'float' || p.type === 'number' ? 'number' : 'text'}
-                                            step={p.type === 'float' || p.type === 'number' ? '0.01' : '1'}
-                                            value={typeof modelParams[p.name] === 'boolean' ? String(modelParams[p.name]) : (modelParams[p.name] ?? '') as string | number}
-                                            onChange={(e) => {
-                                                const val = e.target.value;
-                                                const isNumeric = p.type === 'int' || p.type === 'integer' || p.type === 'float' || p.type === 'number';
-                                                const parsed = isNumeric
-                                                    ? (p.type === 'int' || p.type === 'integer' ? parseInt(val) : parseFloat(val))
-                                                    : val;
-                                                const finalValue = (isNumeric && Number.isNaN(parsed)) ? val : (parsed as ModelParamValue);
-                                                handleUpdateParam(p.name, finalValue, p.type);
-                                            }}
-                                            placeholder={String(p.default)}
-                                            className={`w-full border rounded-md px-2 py-1.5 text-xs focus:outline-none focus:ring-1 ${hasError
-                                                ? 'border-red-300 bg-red-50 focus:ring-red-500'
-                                                : 'border-gray-300 focus:ring-purple-500'
-                                                }`}
-                                        />
-                                        {hasError && (
-                                            <p className="text-[10px] text-red-500 mt-1 flex items-center gap-1">
-                                                <AlertCircle size={10} />
-                                                {paramErrors[p.name]}
-                                            </p>
-                                        )}
-                                    </>
+                                {/* Core Parameters - Always visible */}
+                                {coreParams.length > 0 && (
+                                    <div className="space-y-3">{coreParams.map(renderParam)}</div>
                                 )}
-                                <p className="text-[10px] text-gray-400 mt-0.5 leading-tight">
-                                    {p.description}
-                                </p>
+
+                                {/* Advanced Parameters - Collapsible */}
+                                {advancedParams.length > 0 && (
+                                    <div className="border-t border-gray-200 pt-2 mt-2">
+                                        <button
+                                            type="button"
+                                            onClick={() => setShowAdvanced(!showAdvanced)}
+                                            className="flex items-center gap-1 text-xs font-medium text-gray-500 hover:text-gray-700 w-full"
+                                        >
+                                            {showAdvanced ? (
+                                                <ChevronDown size={12} />
+                                            ) : (
+                                                <ChevronRight size={12} />
+                                            )}
+                                            Advanced ({advancedParams.length})
+                                        </button>
+                                        {showAdvanced && (
+                                            <div className="space-y-3 mt-2">
+                                                {advancedParams.map(renderParam)}
+                                            </div>
+                                        )}
+                                    </div>
+                                )}
+
+                                {/* Internal Parameters - Collapsible */}
+                                {internalParams.length > 0 && (
+                                    <div className="border-t border-gray-200 pt-2 mt-2">
+                                        <button
+                                            type="button"
+                                            onClick={() => setShowInternal(!showInternal)}
+                                            className="flex items-center gap-1 text-xs font-medium text-gray-400 hover:text-gray-600 w-full"
+                                        >
+                                            {showInternal ? (
+                                                <ChevronDown size={12} />
+                                            ) : (
+                                                <ChevronRight size={12} />
+                                            )}
+                                            Internal ({internalParams.length})
+                                        </button>
+                                        {showInternal && (
+                                            <div className="space-y-3 mt-2">
+                                                {internalParams.map(renderParam)}
+                                            </div>
+                                        )}
+                                    </div>
+                                )}
                             </div>
                         );
-                    };
+                    })()}
 
-                    return (
-                        <div className="bg-gray-50 rounded-lg p-3 border border-gray-100 space-y-3">
-                            <div className="flex items-center gap-1.5 text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">
-                                <Settings size={12} />
-                                Hyperparameters
-                            </div>
-
-                            {/* Core Parameters - Always visible */}
-                            {coreParams.length > 0 && (
-                                <div className="space-y-3">
-                                    {coreParams.map(renderParam)}
-                                </div>
-                            )}
-
-                            {/* Advanced Parameters - Collapsible */}
-                            {advancedParams.length > 0 && (
-                                <div className="border-t border-gray-200 pt-2 mt-2">
-                                    <button
-                                        type="button"
-                                        onClick={() => setShowAdvanced(!showAdvanced)}
-                                        className="flex items-center gap-1 text-xs font-medium text-gray-500 hover:text-gray-700 w-full"
-                                    >
-                                        {showAdvanced ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-                                        Advanced ({advancedParams.length})
-                                    </button>
-                                    {showAdvanced && (
-                                        <div className="space-y-3 mt-2">
-                                            {advancedParams.map(renderParam)}
-                                        </div>
-                                    )}
-                                </div>
-                            )}
-
-                            {/* Internal Parameters - Collapsible */}
-                            {internalParams.length > 0 && (
-                                <div className="border-t border-gray-200 pt-2 mt-2">
-                                    <button
-                                        type="button"
-                                        onClick={() => setShowInternal(!showInternal)}
-                                        className="flex items-center gap-1 text-xs font-medium text-gray-400 hover:text-gray-600 w-full"
-                                    >
-                                        {showInternal ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-                                        Internal ({internalParams.length})
-                                    </button>
-                                    {showInternal && (
-                                        <div className="space-y-3 mt-2">
-                                            {internalParams.map(renderParam)}
-                                        </div>
-                                    )}
-                                </div>
-                            )}
-                        </div>
-                    );
-                })()}
-
-                {/* Target column */}
-                <div>
-                    <label className="block text-xs font-medium text-gray-600 mb-1 flex items-center gap-1">
-                        <Target size={12} />
-                        Target Column
-                    </label>
-                    <Dropdown
-                        options={[
-                            { value: '', label: 'Select target...' },
-                            ...numericColumns.map((col): DropdownOption<string> => ({
-                                value: col.name,
-                                label: col.name,
-                            })),
-                        ]}
-                        value={targetColumn}
-                        onChange={setTargetColumn}
-                        placeholder="Select target..."
-                    />
-                </div>
-
-                {/* Feature columns */}
-                <div>
-                    <label className="block text-xs font-medium text-gray-600 mb-1">
-                        Feature Columns ({selectedFeatures.length} selected)
-                    </label>
-                    <div className="border border-gray-200 rounded-md max-h-40 overflow-y-auto">
-                        {numericColumns
-                            .filter((col) => col.name !== targetColumn)
-                            .map((col) => (
-                                <label
-                                    key={col.name}
-                                    className="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-50 cursor-pointer"
-                                >
-                                    <input
-                                        type="checkbox"
-                                        checked={selectedFeatures.includes(col.name)}
-                                        onChange={() => handleToggleFeature(col.name)}
-                                        className="rounded border-gray-300 text-purple-600 focus:ring-purple-500"
-                                    />
-                                    <span className="text-sm">{col.name}</span>
-                                    <span className="text-xs text-gray-400 ml-auto">{col.dtype}</span>
-                                </label>
-                            ))}
+                {/* Save configuration */}
+                <div className="bg-gray-50 rounded-lg p-3 border border-gray-100 space-y-2">
+                    <div className="flex items-center gap-1.5 text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                        <Save size={12} />
+                        Save Configuration
+                    </div>
+                    <div className="flex gap-2">
+                        <input
+                            type="text"
+                            value={configName}
+                            onChange={(e) => setConfigName(e.target.value)}
+                            placeholder="e.g. baseline_linear"
+                            className="flex-1 border border-gray-300 rounded-md px-2 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-purple-500"
+                        />
+                        <button
+                            type="button"
+                            onClick={handleSaveConfig}
+                            disabled={!configName.trim()}
+                            className="px-2.5 py-1.5 text-xs font-medium rounded-md bg-purple-600 text-white hover:bg-purple-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                            Save
+                        </button>
                     </div>
                 </div>
 
-                {/* Test size */}
-                <div>
-                    <label className="block text-xs font-medium text-gray-600 mb-1">
-                        Test Size: {(testSize * 100).toFixed(0)}%
-                    </label>
-                    <input
-                        type="range"
-                        min="0.1"
-                        max="0.4"
-                        step="0.05"
-                        value={testSize}
-                        onChange={(e) => setTestSize(parseFloat(e.target.value))}
-                        className="w-full accent-purple-600"
-                    />
+                {/* Saved configurations */}
+                <div className="bg-gray-50 rounded-lg p-3 border border-gray-100">
+                    <button
+                        type="button"
+                        onClick={() => setShowSavedConfigs(!showSavedConfigs)}
+                        className="flex items-center justify-between w-full text-left"
+                    >
+                        <div className="flex items-center gap-1.5 text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                            <FolderOpen size={12} />
+                            Saved Configurations ({savedConfigs.length})
+                        </div>
+                        {showSavedConfigs ? (
+                            <ChevronDown size={12} className="text-gray-400" />
+                        ) : (
+                            <ChevronRight size={12} className="text-gray-400" />
+                        )}
+                    </button>
+
+                    {showSavedConfigs && (
+                        <div className="mt-2 space-y-2">
+                            {savedConfigs.length === 0 ? (
+                                <p className="text-xs text-gray-400">No saved configurations yet.</p>
+                            ) : (
+                                savedConfigs.map((config) => (
+                                    <div
+                                        key={config.id}
+                                        className="bg-white border border-gray-200 rounded-md p-2"
+                                    >
+                                        <div className="flex items-start justify-between gap-2">
+                                            <div className="min-w-0">
+                                                <div className="text-xs font-medium text-gray-700 truncate">
+                                                    {config.name}
+                                                </div>
+                                                <div className="text-[10px] text-gray-400 mt-0.5">
+                                                    {new Date(config.createdAt).toLocaleString()}
+                                                </div>
+                                            </div>
+                                            <div className="flex items-center gap-1">
+                                                <button
+                                                    type="button"
+                                                    onClick={() => loadConfig(config.id)}
+                                                    className="px-2 py-1 text-[10px] rounded bg-blue-50 text-blue-700 hover:bg-blue-100"
+                                                >
+                                                    Load
+                                                </button>
+                                                <button
+                                                    type="button"
+                                                    onClick={() => deleteConfig(config.id)}
+                                                    className="p-1 rounded text-red-500 hover:bg-red-50"
+                                                    title="Delete configuration"
+                                                >
+                                                    <Trash2 size={11} />
+                                                </button>
+                                            </div>
+                                        </div>
+                                        <div className="mt-1 text-[10px] text-gray-500">
+                                            {config.selectedModel} | {config.selectedFeatures.length}{' '}
+                                            features
+                                        </div>
+                                    </div>
+                                ))
+                            )}
+                        </div>
+                    )}
                 </div>
+
+                {/* Pipeline-dependent controls */}
+                {currentVersionId && (
+                    <>
+                        {/* Target column */}
+                        <div>
+                            <label className="block text-xs font-medium text-gray-600 mb-1 flex items-center gap-1">
+                                <Target size={12} />
+                                Target Column
+                            </label>
+                            <Dropdown
+                                options={[
+                                    { value: '', label: 'Select target...' },
+                                    ...numericColumns.map(
+                                        (col): DropdownOption<string> => ({
+                                            value: col.name,
+                                            label: col.name,
+                                        })
+                                    ),
+                                ]}
+                                value={targetColumn}
+                                onChange={setTargetColumn}
+                                placeholder="Select target..."
+                            />
+                        </div>
+
+                        {/* Feature columns */}
+                        <div>
+                            <label className="block text-xs font-medium text-gray-600 mb-1">
+                                Feature Columns ({selectedFeatures.length} selected)
+                            </label>
+                            <div className="border border-gray-200 rounded-md max-h-40 overflow-y-auto">
+                                {numericColumns
+                                    .filter((col) => col.name !== targetColumn)
+                                    .map((col) => (
+                                        <label
+                                            key={col.name}
+                                            className="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-50 cursor-pointer"
+                                        >
+                                            <input
+                                                type="checkbox"
+                                                checked={selectedFeatures.includes(col.name)}
+                                                onChange={() => toggleFeature(col.name)}
+                                                className="rounded border-gray-300 text-purple-600 focus:ring-purple-500"
+                                            />
+                                            <span className="text-sm">{col.name}</span>
+                                            <span className="text-xs text-gray-400 ml-auto">
+                                                {col.dtype}
+                                            </span>
+                                        </label>
+                                    ))}
+                            </div>
+                        </div>
+
+                        {/* Test size */}
+                        <div>
+                            <label className="block text-xs font-medium text-gray-600 mb-1">
+                                Test Size: {(testSize * 100).toFixed(0)}%
+                            </label>
+                            <input
+                                type="range"
+                                min="0.1"
+                                max="0.4"
+                                step="0.05"
+                                value={testSize}
+                                onChange={(e) => setTestSize(parseFloat(e.target.value))}
+                                className="w-full accent-purple-600"
+                            />
+                        </div>
+                    </>
+                )}
+
+                {!currentVersionId && (
+                    <div className="rounded-md border border-amber-200 bg-amber-50 p-2 text-xs text-amber-700">
+                        Create a pipeline first to select target/features and fit a model.
+                    </div>
+                )}
 
                 {/* Fit button */}
                 <button
                     onClick={handleFit}
-                    disabled={isFitting || !targetColumn || selectedFeatures.length === 0 || currentModelType?.coming_soon}
+                    disabled={isFitDisabled}
                     className="w-full flex items-center justify-center gap-2 bg-purple-600 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-purple-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                 >
                     {isFitting ? (
@@ -570,10 +880,10 @@ export const ModelsPanel = () => {
                             <Loader2 size={14} className="animate-spin" />
                             Fitting...
                         </>
+                    ) : !currentVersionId ? (
+                        <>Create a pipeline first</>
                     ) : currentModelType?.coming_soon ? (
-                        <>
-                            Coming Soon
-                        </>
+                        <>Coming Soon</>
                     ) : (
                         <>
                             <Play size={14} />
@@ -582,19 +892,23 @@ export const ModelsPanel = () => {
                     )}
                 </button>
 
-
                 {/* Errors */}
                 {fitErrors.length > 0 && (
                     <div className="bg-red-50 border border-red-200 rounded-md p-3 space-y-2">
                         {fitErrors.map((error, idx) => (
                             <div key={idx} className="text-sm">
                                 <div className="flex items-start gap-2">
-                                    <AlertCircle size={14} className="text-red-500 mt-0.5 flex-shrink-0" />
+                                    <AlertCircle
+                                        size={14}
+                                        className="text-red-500 mt-0.5 flex-shrink-0"
+                                    />
                                     <div className="flex-1">
-                                        <div className="text-red-700 font-medium">{error.message}</div>
+                                        <div className="text-red-700 font-medium">
+                                            {error.message}
+                                        </div>
                                         {error.suggestion && (
                                             <div className="text-red-600 text-xs mt-1">
-                                                💡 {error.suggestion}
+                                                Tip: {error.suggestion}
                                             </div>
                                         )}
                                         {error.field && (
@@ -622,7 +936,10 @@ export const ModelsPanel = () => {
                             <h4 className="text-xs font-medium text-gray-600 mb-1">Metrics</h4>
                             <div className="grid grid-cols-2 gap-1 text-xs">
                                 {Object.entries(fitResult.metrics).map(([key, value]) => (
-                                    <div key={key} className="flex justify-between items-center bg-white rounded px-2 py-1">
+                                    <div
+                                        key={key}
+                                        className="flex justify-between items-center bg-white rounded px-2 py-1"
+                                    >
                                         <div className="flex items-center gap-1.5">
                                             <span className="text-gray-500">{key}:</span>
                                             {key.toLowerCase() === 'r2' && (
@@ -638,7 +955,9 @@ export const ModelsPanel = () => {
                                             )}
                                         </div>
                                         <span className="font-mono text-gray-700">
-                                            {typeof value === 'number' ? value.toFixed(4) : value}
+                                            {typeof value === 'number'
+                                                ? value.toFixed(4)
+                                                : value}
                                         </span>
                                     </div>
                                 ))}
@@ -648,17 +967,26 @@ export const ModelsPanel = () => {
                         {/* Coefficients */}
                         {fitResult.coefficients && (
                             <div>
-                                <h4 className="text-xs font-medium text-gray-600 mb-1">Coefficients</h4>
+                                <h4 className="text-xs font-medium text-gray-600 mb-1">
+                                    Coefficients
+                                </h4>
                                 <div className="space-y-1 text-xs">
                                     {Object.entries(fitResult.coefficients).map(([key, value]) => (
                                         <div
                                             key={key}
                                             className="flex items-center gap-2 bg-white rounded px-2 py-1"
                                         >
-                                            <span className="text-gray-500 truncate flex-1">{key}</span>
-                                            <ArrowRight size={10} className="text-gray-300" />
+                                            <span className="text-gray-500 truncate flex-1">
+                                                {key}
+                                            </span>
+                                            <ArrowRight
+                                                size={10}
+                                                className="text-gray-300"
+                                            />
                                             <span className="font-mono">
-                                                {typeof value === 'number' ? value.toFixed(4) : value}
+                                                {typeof value === 'number'
+                                                    ? value.toFixed(4)
+                                                    : value}
                                             </span>
                                         </div>
                                     ))}
@@ -690,15 +1018,27 @@ export const ModelsPanel = () => {
                                         </div>
                                     </div>
                                     <div className="flex items-center gap-2 text-[10px] text-gray-500">
-                                        <span className="bg-gray-100 px-1 rounded">{model.model_type}</span>
+                                        <span className="bg-gray-100 px-1 rounded">
+                                            {model.model_type}
+                                        </span>
                                         <span>•</span>
-                                        <span>Target: <span className="text-gray-700">{model.target_column}</span></span>
+                                        <span>
+                                            Target:{' '}
+                                            <span className="text-gray-700">
+                                                {model.target_column}
+                                            </span>
+                                        </span>
                                     </div>
                                     <div className="mt-2 grid grid-cols-2 gap-x-2 gap-y-1">
                                         {Object.entries(model.metrics).map(([key, value]) => (
-                                            <div key={key} className="flex justify-between items-center text-[10px]">
+                                            <div
+                                                key={key}
+                                                className="flex justify-between items-center text-[10px]"
+                                            >
                                                 <div className="flex items-center gap-1">
-                                                    <span className="text-gray-400 capitalize">{key}:</span>
+                                                    <span className="text-gray-400 capitalize">
+                                                        {key}:
+                                                    </span>
                                                     {key.toLowerCase() === 'r2' && (
                                                         <a
                                                             href="https://youtube.com/watch?v=2AQKmw14mHM"

--- a/frontend/src/components/Pipeline/PipelineComponents.test.tsx
+++ b/frontend/src/components/Pipeline/PipelineComponents.test.tsx
@@ -18,6 +18,21 @@ import {
     selectCurrentVersionId,
 } from '../../stores/pipelineStore';
 import { useProjectStore } from '../../stores/projectStore';
+import {
+    useModelingStore,
+    selectModelTypes,
+    selectIsLoadingModelTypes,
+    selectSelectedModel,
+    selectModelName,
+    selectModelParams,
+    selectParamErrors,
+    selectTestSize,
+    selectTargetColumn,
+    selectSelectedFeatures,
+    selectShowAdvanced,
+    selectShowInternal,
+    selectSavedConfigs,
+} from '../../stores/modelingStore';
 import type { TransformInfo, PipelineStep, SchemaColumn } from '../../api/pipelineApi';
 
 // Mock the stores
@@ -37,30 +52,20 @@ vi.mock('../../stores/projectStore', () => ({
     useProjectStore: vi.fn(),
 }));
 
-// Mock Lucide icons
-vi.mock('lucide-react', () => ({
-    Plus: () => <div data-testid="plus-icon" />,
-    Trash2: () => <div data-testid="trash-icon" />,
-    Play: () => <div data-testid="play-icon" />,
-    Brain: () => <div data-testid="brain-icon" />,
-    Info: () => <div data-testid="info-icon" />,
-    AlertCircle: () => <div data-testid="alert-icon" />,
-    Loader2: () => <div data-testid="loader-icon" />,
-    ArrowRight: () => <div data-testid="arrow-right-icon" />,
-    BarChart3: () => <div data-testid="bar-chart-icon" />,
-    History: () => <div data-testid="history-icon" />,
-    ChevronDown: () => <div data-testid="chevron-down-icon" />,
-    ChevronUp: () => <div data-testid="chevron-up-icon" />,
-    Search: () => <div data-testid="search-icon" />,
-    Layers: () => <div data-testid="layers-icon" />,
-    Target: () => <div data-testid="target-icon" />,
-    Cpu: () => <div data-testid="cpu-icon" />,
-    Settings: () => <div data-testid="settings-icon" />,
-    Database: () => <div data-testid="database-icon" />,
-    Table: () => <div data-testid="table-icon" />,
-    FileText: () => <div data-testid="file-text-icon" />,
-    Save: () => <div data-testid="save-icon" />,
-    X: () => <div data-testid="x-icon" />,
+vi.mock('../../stores/modelingStore', () => ({
+    useModelingStore: vi.fn(),
+    selectModelTypes: vi.fn(),
+    selectIsLoadingModelTypes: vi.fn(),
+    selectSelectedModel: vi.fn(),
+    selectModelName: vi.fn(),
+    selectModelParams: vi.fn(),
+    selectParamErrors: vi.fn(),
+    selectTestSize: vi.fn(),
+    selectTargetColumn: vi.fn(),
+    selectSelectedFeatures: vi.fn(),
+    selectShowAdvanced: vi.fn(),
+    selectShowInternal: vi.fn(),
+    selectSavedConfigs: vi.fn(),
 }));
 
 describe('Pipeline Workbench Components Smoke Tests', () => {
@@ -86,7 +91,7 @@ describe('Pipeline Workbench Components Smoke Tests', () => {
         vi.mocked(selectIsApplyingStep).mockReturnValue(false);
         vi.mocked(selectFormulaBarError).mockReturnValue(null);
         vi.mocked(selectCurrentPipelineId).mockReturnValue('p1');
-        vi.mocked(selectCurrentVersionId).mockReturnValue('v1');
+        vi.mocked(selectCurrentVersionId).mockReturnValue(null);
 
         // Default mock for usePipelineStore
         vi.mocked(usePipelineStore).mockImplementation((selector: unknown) => {
@@ -98,7 +103,7 @@ describe('Pipeline Workbench Components Smoke Tests', () => {
                     isApplyingStep: false,
                     formulaBarError: null,
                     currentPipelineId: 'p1',
-                    currentVersionId: 'v1',
+                    currentVersionId: null,
                     setFormulaBarError: vi.fn(),
                     addStep: vi.fn(),
                     materialize: vi.fn(),
@@ -109,6 +114,52 @@ describe('Pipeline Workbench Components Smoke Tests', () => {
             return {
                 setFormulaBarError: vi.fn(),
             };
+        });
+
+        vi.mocked(selectModelTypes).mockReturnValue([]);
+        vi.mocked(selectIsLoadingModelTypes).mockReturnValue(false);
+        vi.mocked(selectSelectedModel).mockReturnValue('linear_regression');
+        vi.mocked(selectModelName).mockReturnValue('');
+        vi.mocked(selectModelParams).mockReturnValue({});
+        vi.mocked(selectParamErrors).mockReturnValue({});
+        vi.mocked(selectTestSize).mockReturnValue(0.2);
+        vi.mocked(selectTargetColumn).mockReturnValue('');
+        vi.mocked(selectSelectedFeatures).mockReturnValue([]);
+        vi.mocked(selectShowAdvanced).mockReturnValue(false);
+        vi.mocked(selectShowInternal).mockReturnValue(false);
+        vi.mocked(selectSavedConfigs).mockReturnValue([]);
+
+        vi.mocked(useModelingStore).mockImplementation((selector: unknown) => {
+            if (typeof selector === 'function') {
+                const mockState = {
+                    modelTypes: [],
+                    isLoadingModelTypes: false,
+                    selectedModel: 'linear_regression',
+                    modelName: '',
+                    modelParams: {},
+                    paramErrors: {},
+                    testSize: 0.2,
+                    targetColumn: '',
+                    selectedFeatures: [],
+                    showAdvanced: false,
+                    showInternal: false,
+                    savedConfigs: [],
+                    fetchModelTypes: vi.fn(),
+                    setSelectedModel: vi.fn(),
+                    setModelName: vi.fn(),
+                    setTestSize: vi.fn(),
+                    setTargetColumn: vi.fn(),
+                    toggleFeature: vi.fn(),
+                    setShowAdvanced: vi.fn(),
+                    setShowInternal: vi.fn(),
+                    updateParam: vi.fn(),
+                    saveCurrentConfig: vi.fn(),
+                    loadConfig: vi.fn(),
+                    deleteConfig: vi.fn(),
+                };
+                return (selector as (state: typeof mockState) => unknown)(mockState);
+            }
+            return undefined;
         });
     });
 

--- a/frontend/src/components/Toolbar/Toolbar.tsx
+++ b/frontend/src/components/Toolbar/Toolbar.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { CheckCircle, Download, Upload, Trash2, Save, ArrowUpRight } from 'lucide-react';
-import { SignedIn, SignedOut, SignInButton, UserButton } from '@clerk/clerk-react';
+import { SignInButton, UserButton, useAuth } from '@clerk/clerk-react';
 import { useDAGStore, selectActiveMainTab } from '../../stores/dagStore';
 import { useProjectStore } from '../../stores/projectStore';
 import { dagApi, downloadBlob } from '../../services/api';
@@ -8,10 +8,13 @@ import { useToast } from '../common';
 import { AddNodeDropdown } from './AddNodeDropdown';
 import { GenerateButton } from './GenerateButton';
 import { ValidationStatus } from './ValidationStatus';
+import { isAuthBypassed } from '../../utils/auth';
 
 import { NewProjectDialog } from '../ProjectSidebar/NewProjectDialog';
 
 export const Toolbar: React.FC = () => {
+  const { isSignedIn } = useAuth();
+  const authBypassed = isAuthBypassed();
   const [isValidating, setIsValidating] = useState(false);
   const [isPreviewing, setIsPreviewing] = useState(false);
   const [isNewProjectDialogOpen, setIsNewProjectDialogOpen] = useState(false);
@@ -460,16 +463,21 @@ export const Toolbar: React.FC = () => {
 
         {/* Auth */}
         <div className="ml-2 pl-2 border-l border-gray-200 flex items-center">
-          <SignedOut>
+          {authBypassed && (
+            <span className="px-2 py-1 text-xs font-medium rounded bg-amber-100 text-amber-800">
+              Local Auth Bypass
+            </span>
+          )}
+          {!authBypassed && !isSignedIn && (
             <SignInButton mode="modal">
               <button className="px-3 py-1.5 bg-gray-900 text-white text-sm font-medium rounded hover:bg-gray-800 transition-colors">
                 Sign In
               </button>
             </SignInButton>
-          </SignedOut>
-          <SignedIn>
+          )}
+          {!authBypassed && isSignedIn && (
             <UserButton />
-          </SignedIn>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/components/common/Dropdown.tsx
+++ b/frontend/src/components/common/Dropdown.tsx
@@ -171,7 +171,7 @@ export function Dropdown<T = string>({
             {isOpen && (
                 <div
                     ref={listRef}
-                    className="absolute z-50 w-full mt-1 bg-white border border-gray-200 rounded-lg shadow-lg max-h-60 overflow-auto"
+                    className="absolute z-50 w-full mt-1 bg-white border border-gray-200 rounded-lg shadow-lg max-h-80 overflow-auto"
                 >
                     {options.map((option, index) => {
                         const isSelected = option.value === value;

--- a/frontend/src/stores/modelingStore.ts
+++ b/frontend/src/stores/modelingStore.ts
@@ -1,0 +1,342 @@
+import { create } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+import {
+    modelingApi,
+    type ModelTypeInfo,
+    type ModelParamValue,
+} from '../api/modelingApi';
+
+const SAVED_CONFIGS_KEY = 'data-simulator-model-configs';
+const DEFAULT_MODEL_NAME = 'linear_regression';
+
+export interface SavedModelConfig {
+    id: string;
+    name: string;
+    createdAt: string;
+    selectedModel: string;
+    modelName: string;
+    modelParams: Record<string, ModelParamValue>;
+    testSize: number;
+    targetColumn: string;
+    selectedFeatures: string[];
+    showAdvanced: boolean;
+    showInternal: boolean;
+}
+
+interface ModelingState {
+    modelTypes: ModelTypeInfo[];
+    isLoadingModelTypes: boolean;
+    modelTypesLoaded: boolean;
+
+    selectedModel: string;
+    modelName: string;
+    modelParams: Record<string, ModelParamValue>;
+    paramErrors: Record<string, string>;
+    testSize: number;
+    targetColumn: string;
+    selectedFeatures: string[];
+    showAdvanced: boolean;
+    showInternal: boolean;
+
+    savedConfigs: SavedModelConfig[];
+}
+
+interface ModelingActions {
+    fetchModelTypes: () => Promise<void>;
+    setSelectedModel: (name: string) => void;
+    setModelName: (name: string) => void;
+    setTargetColumn: (column: string) => void;
+    toggleFeature: (column: string) => void;
+    setTestSize: (size: number) => void;
+    setShowAdvanced: (show: boolean) => void;
+    setShowInternal: (show: boolean) => void;
+    updateParam: (name: string, value: ModelParamValue, type: string) => void;
+
+    saveCurrentConfig: (configName: string) => SavedModelConfig | null;
+    loadConfig: (id: string) => void;
+    deleteConfig: (id: string) => void;
+}
+
+function loadSavedConfigs(): SavedModelConfig[] {
+    if (typeof window === 'undefined') {
+        return [];
+    }
+
+    try {
+        const raw = localStorage.getItem(SAVED_CONFIGS_KEY);
+        if (!raw) {
+            return [];
+        }
+        const parsed = JSON.parse(raw) as SavedModelConfig[];
+        return Array.isArray(parsed) ? parsed : [];
+    } catch (error) {
+        console.warn('Failed to parse saved model configs:', error);
+        return [];
+    }
+}
+
+function persistSavedConfigs(configs: SavedModelConfig[]): void {
+    if (typeof window === 'undefined') {
+        return;
+    }
+
+    try {
+        localStorage.setItem(SAVED_CONFIGS_KEY, JSON.stringify(configs));
+    } catch (error) {
+        console.warn('Failed to persist model configs:', error);
+    }
+}
+
+function getDefaultModelName(modelTypes: ModelTypeInfo[]): string {
+    const linearRegression = modelTypes.find((model) => model.name === DEFAULT_MODEL_NAME);
+    if (linearRegression) {
+        return linearRegression.name;
+    }
+    return modelTypes[0]?.name ?? DEFAULT_MODEL_NAME;
+}
+
+function getDefaultParams(
+    modelTypes: ModelTypeInfo[],
+    modelName: string
+): Record<string, ModelParamValue> {
+    const model = modelTypes.find((item) => item.name === modelName);
+    if (!model) {
+        return {};
+    }
+
+    const defaults: Record<string, ModelParamValue> = {};
+    model.parameters.forEach((param) => {
+        defaults[param.name] = param.default;
+    });
+    return defaults;
+}
+
+const initialState: ModelingState = {
+    modelTypes: [],
+    isLoadingModelTypes: false,
+    modelTypesLoaded: false,
+
+    selectedModel: DEFAULT_MODEL_NAME,
+    modelName: '',
+    modelParams: {},
+    paramErrors: {},
+    testSize: 0.2,
+    targetColumn: '',
+    selectedFeatures: [],
+    showAdvanced: false,
+    showInternal: false,
+
+    savedConfigs: loadSavedConfigs(),
+};
+
+export const useModelingStore = create<ModelingState & ModelingActions>()(
+    immer((set, get) => ({
+        ...initialState,
+
+        fetchModelTypes: async () => {
+            const { modelTypesLoaded, isLoadingModelTypes } = get();
+            if (modelTypesLoaded || isLoadingModelTypes) {
+                return;
+            }
+
+            set((state) => {
+                state.isLoadingModelTypes = true;
+            });
+
+            try {
+                const modelTypes = await modelingApi.listModels();
+                set((state) => {
+                    state.modelTypes = modelTypes;
+                    state.modelTypesLoaded = true;
+                    state.isLoadingModelTypes = false;
+
+                    const hasSelectedModel = modelTypes.some(
+                        (model) => model.name === state.selectedModel
+                    );
+                    const selectedModel = hasSelectedModel
+                        ? state.selectedModel
+                        : getDefaultModelName(modelTypes);
+
+                    const shouldResetParams =
+                        selectedModel !== state.selectedModel ||
+                        Object.keys(state.modelParams).length === 0;
+                    state.selectedModel = selectedModel;
+                    if (shouldResetParams) {
+                        state.modelParams = getDefaultParams(modelTypes, selectedModel);
+                        state.paramErrors = {};
+                    }
+                });
+            } catch (error) {
+                set((state) => {
+                    state.isLoadingModelTypes = false;
+                });
+                console.error('Failed to load model types:', error);
+            }
+        },
+
+        setSelectedModel: (name) => {
+            const { modelTypes } = get();
+            set((state) => {
+                state.selectedModel = name;
+                state.modelParams = getDefaultParams(modelTypes, name);
+                state.paramErrors = {};
+            });
+        },
+
+        setModelName: (name) => {
+            set((state) => {
+                state.modelName = name;
+            });
+        },
+
+        setTargetColumn: (column) => {
+            set((state) => {
+                state.targetColumn = column;
+                state.selectedFeatures = state.selectedFeatures.filter(
+                    (feature) => feature !== column
+                );
+            });
+        },
+
+        toggleFeature: (column) => {
+            set((state) => {
+                if (state.selectedFeatures.includes(column)) {
+                    state.selectedFeatures = state.selectedFeatures.filter(
+                        (feature) => feature !== column
+                    );
+                    return;
+                }
+                state.selectedFeatures.push(column);
+            });
+        },
+
+        setTestSize: (size) => {
+            set((state) => {
+                state.testSize = size;
+            });
+        },
+
+        setShowAdvanced: (show) => {
+            set((state) => {
+                state.showAdvanced = show;
+            });
+        },
+
+        setShowInternal: (show) => {
+            set((state) => {
+                state.showInternal = show;
+            });
+        },
+
+        updateParam: (name, value, type) => {
+            let error = '';
+            if (value !== '' && value !== null && value !== undefined) {
+                if (type === 'int' || type === 'integer') {
+                    const n = Number(value);
+                    if (!Number.isInteger(n)) {
+                        error = 'Must be an integer';
+                    }
+                } else if (type === 'float' || type === 'number') {
+                    const n = Number(value);
+                    if (Number.isNaN(n)) {
+                        error = 'Must be a number';
+                    }
+                }
+            }
+
+            set((state) => {
+                state.modelParams[name] = value;
+                state.paramErrors[name] = error;
+            });
+        },
+
+        saveCurrentConfig: (configName) => {
+            const name = configName.trim();
+            if (!name) {
+                return null;
+            }
+
+            const {
+                selectedModel,
+                modelName,
+                modelParams,
+                testSize,
+                targetColumn,
+                selectedFeatures,
+                showAdvanced,
+                showInternal,
+            } = get();
+
+            const config: SavedModelConfig = {
+                id: `cfg_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+                name,
+                createdAt: new Date().toISOString(),
+                selectedModel,
+                modelName,
+                modelParams: { ...modelParams },
+                testSize,
+                targetColumn,
+                selectedFeatures: [...selectedFeatures],
+                showAdvanced,
+                showInternal,
+            };
+
+            set((state) => {
+                state.savedConfigs.unshift(config);
+                persistSavedConfigs(state.savedConfigs);
+            });
+
+            return config;
+        },
+
+        loadConfig: (id) => {
+            const config = get().savedConfigs.find((item) => item.id === id);
+            if (!config) {
+                return;
+            }
+
+            set((state) => {
+                state.selectedModel = config.selectedModel;
+                state.modelName = config.modelName;
+                state.modelParams = { ...config.modelParams };
+                state.paramErrors = {};
+                state.testSize = config.testSize;
+                state.targetColumn = config.targetColumn;
+                state.selectedFeatures = config.selectedFeatures.filter(
+                    (feature) => feature !== config.targetColumn
+                );
+                state.showAdvanced = config.showAdvanced;
+                state.showInternal = config.showInternal;
+            });
+        },
+
+        deleteConfig: (id) => {
+            set((state) => {
+                state.savedConfigs = state.savedConfigs.filter((config) => config.id !== id);
+                persistSavedConfigs(state.savedConfigs);
+            });
+        },
+    }))
+);
+
+export const selectModelTypes = (state: ModelingState & ModelingActions) => state.modelTypes;
+export const selectIsLoadingModelTypes = (state: ModelingState & ModelingActions) =>
+    state.isLoadingModelTypes;
+export const selectModelTypesLoaded = (state: ModelingState & ModelingActions) =>
+    state.modelTypesLoaded;
+export const selectSelectedModel = (state: ModelingState & ModelingActions) =>
+    state.selectedModel;
+export const selectModelName = (state: ModelingState & ModelingActions) => state.modelName;
+export const selectModelParams = (state: ModelingState & ModelingActions) => state.modelParams;
+export const selectParamErrors = (state: ModelingState & ModelingActions) => state.paramErrors;
+export const selectTestSize = (state: ModelingState & ModelingActions) => state.testSize;
+export const selectTargetColumn = (state: ModelingState & ModelingActions) =>
+    state.targetColumn;
+export const selectSelectedFeatures = (state: ModelingState & ModelingActions) =>
+    state.selectedFeatures;
+export const selectShowAdvanced = (state: ModelingState & ModelingActions) =>
+    state.showAdvanced;
+export const selectShowInternal = (state: ModelingState & ModelingActions) =>
+    state.showInternal;
+export const selectSavedConfigs = (state: ModelingState & ModelingActions) =>
+    state.savedConfigs;

--- a/frontend/src/utils/auth.ts
+++ b/frontend/src/utils/auth.ts
@@ -1,0 +1,11 @@
+export const isAuthBypassed = (): boolean => {
+  if (import.meta.env.VITE_AUTH_BYPASS === 'true') {
+    return true;
+  }
+
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  return window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+};


### PR DESCRIPTION
## Summary
- add new Zustand modeling store to persist model form state and cache model catalog
- refactor Models panel to use shared store state, remove early no-pipeline return, and add save/load/delete model configurations via localStorage
- allow opening the Models sub-tab before pipeline creation when DAG preview exists
- enrich model dropdown options and slightly increase dropdown max height for readability
- add local development auth bypass support for frontend and backend (`VITE_AUTH_BYPASS`, `DS_AUTH_BYPASS`) to unblock localhost access

## Validation
- `cd frontend && npm run build`
- `cd frontend && npm run test:run -- src/components/Pipeline`
- manual local verification of health + protected endpoint in bypass mode:
  - `GET /health` -> 200
  - `GET /api/projects` (without token, with `DS_AUTH_BYPASS=true`) -> 200
