### PR TITLE
Add tenant-scoped authorization, project visibility, and forking

### DIFF
--- a/backend/alembic/versions/a7c1f2d4e9b3_add_tenant_visibility_and_forking.py
+++ b/backend/alembic/versions/a7c1f2d4e9b3_add_tenant_visibility_and_forking.py
@@ -1,0 +1,57 @@
+"""add tenant ownership, visibility, and project forking metadata
+
+Revision ID: a7c1f2d4e9b3
+Revises: 9c1a2f7e4b11
+Create Date: 2026-02-15 10:30:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a7c1f2d4e9b3"
+down_revision: Union[str, Sequence[str], None] = "9c1a2f7e4b11"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("projects") as batch_op:
+        batch_op.add_column(sa.Column("owner_user_id", sa.Text(), nullable=True, server_default="legacy"))
+        batch_op.add_column(sa.Column("visibility", sa.Text(), nullable=False, server_default="private"))
+        batch_op.add_column(sa.Column("forked_from_project_id", sa.String(length=36), nullable=True))
+
+    op.execute("UPDATE projects SET owner_user_id = 'legacy' WHERE owner_user_id IS NULL OR TRIM(owner_user_id) = ''")
+    op.execute("UPDATE projects SET visibility = 'private' WHERE visibility IS NULL")
+
+    with op.batch_alter_table("projects") as batch_op:
+        batch_op.alter_column("owner_user_id", nullable=False, server_default=None)
+        batch_op.create_index("ix_projects_owner_user_id", ["owner_user_id"], unique=False)
+        batch_op.create_index("ix_projects_visibility", ["visibility"], unique=False)
+        batch_op.create_index("ix_projects_forked_from_project_id", ["forked_from_project_id"], unique=False)
+        batch_op.create_check_constraint(
+            "ck_projects_visibility",
+            "visibility IN ('private', 'public')",
+        )
+        batch_op.create_foreign_key(
+            "fk_projects_forked_from_project_id",
+            "projects",
+            ["forked_from_project_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("projects") as batch_op:
+        batch_op.drop_constraint("fk_projects_forked_from_project_id", type_="foreignkey")
+        batch_op.drop_constraint("ck_projects_visibility", type_="check")
+        batch_op.drop_index("ix_projects_forked_from_project_id")
+        batch_op.drop_index("ix_projects_visibility")
+        batch_op.drop_index("ix_projects_owner_user_id")
+        batch_op.drop_column("forked_from_project_id")
+        batch_op.drop_column("visibility")
+        batch_op.drop_column("owner_user_id")

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -3,7 +3,7 @@ from functools import lru_cache
 from typing import Any
 
 import jwt
-from fastapi import HTTPException, Request, status
+from fastapi import Depends, HTTPException, Request, status
 from jwt import PyJWKClient
 
 from app.core.config import settings
@@ -119,6 +119,11 @@ def require_user_id(user: dict[str, Any]) -> str:
     if not user_id:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
     return user_id
+
+
+def current_user_context(user: dict[str, Any] = Depends(require_auth)) -> dict[str, str]:
+    """Return normalized current-user context for route dependencies."""
+    return {"user_id": require_user_id(user)}
 
 
 # Alias for compatibility

--- a/backend/app/core/project_access.py
+++ b/backend/app/core/project_access.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import NoReturn
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from app.db.models import Project
+
+
+def raise_not_found() -> NoReturn:
+    """Raise the canonical not-found response for inaccessible resources."""
+    raise HTTPException(status_code=404, detail="Not found")
+
+
+def require_project_read(db: Session, project_id: str, user_id: str) -> Project:
+    """Return project if current user can read it, else raise not found."""
+    project = db.get(Project, project_id)
+    if not project:
+        raise_not_found()
+    if project.owner_user_id == user_id or project.visibility == "public":
+        return project
+    raise_not_found()
+
+
+def require_project_owner(db: Session, project_id: str, user_id: str) -> Project:
+    """Return project if current user owns it, else raise not found."""
+    project = db.get(Project, project_id)
+    if not project:
+        raise_not_found()
+    if project.owner_user_id == user_id:
+        return project
+    raise_not_found()

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -6,7 +6,18 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Index, Integer, String, Text, func, text
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    func,
+    text,
+)
 from sqlalchemy.dialects.sqlite import JSON
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -25,9 +36,20 @@ class Project(Base):
     """Project model for storing DAG projects."""
 
     __tablename__ = "projects"
+    __table_args__ = (
+        Index("ix_projects_owner_user_id", "owner_user_id"),
+        Index("ix_projects_visibility", "visibility"),
+        Index("ix_projects_forked_from_project_id", "forked_from_project_id"),
+        CheckConstraint("visibility IN ('private', 'public')", name="ck_projects_visibility"),
+    )
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=generate_uuid)
     name: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
+    owner_user_id: Mapped[str] = mapped_column(String(255), nullable=False, default="legacy")
+    visibility: Mapped[str] = mapped_column(String(20), nullable=False, default="private")
+    forked_from_project_id: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("projects.id", ondelete="SET NULL"), nullable=True
+    )
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime, server_default=func.now(), nullable=False

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -45,8 +45,8 @@ class Project(Base):
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=generate_uuid)
     name: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
-    owner_user_id: Mapped[str] = mapped_column(String(255), nullable=False, default="legacy")
-    visibility: Mapped[str] = mapped_column(String(20), nullable=False, default="private")
+    owner_user_id: Mapped[str] = mapped_column(Text, nullable=False, default="legacy")
+    visibility: Mapped[str] = mapped_column(Text, nullable=False, default="private")
     forked_from_project_id: Mapped[str | None] = mapped_column(
         String(36), ForeignKey("projects.id", ondelete="SET NULL"), nullable=True
     )

--- a/backend/tests/test_alembic_tenant_visibility_migration.py
+++ b/backend/tests/test_alembic_tenant_visibility_migration.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.exc import IntegrityError
+
+from app.core.config import settings
+
+OLD_REVISION = "9c1a2f7e4b11"
+NEW_REVISION = "a7c1f2d4e9b3"
+
+
+def _alembic_config(db_url: str) -> Config:
+    backend_dir = Path(__file__).resolve().parents[1]
+    cfg = Config(str(backend_dir / "alembic.ini"))
+    cfg.set_main_option("script_location", str(backend_dir / "alembic"))
+    cfg.set_main_option("sqlalchemy.url", db_url)
+    return cfg
+
+
+def test_tenant_visibility_migration_backfills_and_adds_constraints(tmp_path: Path):
+    db_path = tmp_path / "migration_test.db"
+    db_url = f"sqlite:///{db_path}"
+    cfg = _alembic_config(db_url)
+    original_db_url = settings.database_url
+    settings.database_url = db_url
+    try:
+        command.upgrade(cfg, OLD_REVISION)
+
+        engine = create_engine(db_url)
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO projects (id, name, description)
+                    VALUES ('proj-legacy-1', 'Legacy Project', 'migrated row')
+                    """
+                )
+            )
+
+        command.upgrade(cfg, NEW_REVISION)
+
+        inspector = inspect(engine)
+        columns = {col["name"] for col in inspector.get_columns("projects")}
+        assert "owner_user_id" in columns
+        assert "visibility" in columns
+        assert "forked_from_project_id" in columns
+
+        indexes = {idx["name"] for idx in inspector.get_indexes("projects")}
+        assert "ix_projects_owner_user_id" in indexes
+        assert "ix_projects_visibility" in indexes
+        assert "ix_projects_forked_from_project_id" in indexes
+
+        with engine.begin() as conn:
+            row = conn.execute(
+                text("SELECT owner_user_id, visibility FROM projects WHERE id = 'proj-legacy-1'")
+            ).one()
+            assert row.owner_user_id == "legacy"
+            assert row.visibility == "private"
+
+        with pytest.raises(IntegrityError):
+            with engine.begin() as conn:
+                conn.execute(text("UPDATE projects SET visibility = 'invalid' WHERE id = 'proj-legacy-1'"))
+
+        engine.dispose()
+    finally:
+        settings.database_url = original_db_url

--- a/backend/tests/test_pipeline_upload.py
+++ b/backend/tests/test_pipeline_upload.py
@@ -103,7 +103,7 @@ def test_create_pipeline_from_upload_forbidden_for_non_owner(client: TestClient)
         },
         headers={"x-test-user": "bob"},
     )
-    assert response.status_code == 403
+    assert response.status_code == 404
 
 
 def test_create_pipeline_from_upload_rejects_cross_project_source(client: TestClient):

--- a/backend/tests/test_tenant_authz_and_forking_api.py
+++ b/backend/tests/test_tenant_authz_and_forking_api.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import io
+
+import pytest
+from fastapi import Request
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.core.auth import require_auth
+from app.db.database import Base, get_db
+from app.db.models import Project
+from app.main import app
+
+
+@pytest.fixture(scope="function")
+def test_context():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    async def override_require_auth(request: Request):
+        user = request.headers.get("x-test-user", "user_A")
+        return {"sub": user}
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[require_auth] = override_require_auth
+
+    with TestClient(app) as client:
+        yield client, TestingSessionLocal
+
+    app.dependency_overrides.clear()
+    Base.metadata.drop_all(bind=engine)
+    engine.dispose()
+
+
+def _sample_dag() -> dict:
+    return {
+        "schema_version": "1.0",
+        "nodes": [
+            {
+                "id": "income",
+                "name": "income",
+                "kind": "stochastic",
+                "dtype": "float",
+                "scope": "row",
+                "distribution": {"type": "normal", "params": {"mu": 50000, "sigma": 10000}},
+            }
+        ],
+        "edges": [],
+        "context": {},
+        "metadata": {"sample_size": 100, "seed": 42, "preview_rows": 10},
+    }
+
+
+def _create_project(client: TestClient, *, user: str, name: str, visibility: str = "private", with_dag: bool = False) -> dict:
+    payload = {"name": name, "visibility": visibility}
+    if with_dag:
+        payload["dag_definition"] = _sample_dag()
+    response = client.post("/api/projects", json=payload, headers={"x-test-user": user})
+    assert response.status_code == 201
+    return response.json()
+
+
+def _create_pipeline_simulation(client: TestClient, *, user: str, project_id: str, dag_version_id: str) -> dict:
+    response = client.post(
+        "/api/pipelines",
+        json={
+            "project_id": project_id,
+            "name": "Pipeline 1",
+            "source": {
+                "type": "simulation",
+                "dag_version_id": dag_version_id,
+                "seed": 42,
+                "sample_size": 100,
+            },
+        },
+        headers={"x-test-user": user},
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+def _upload_source(client: TestClient, *, user: str, project_id: str) -> str:
+    csv_bytes = b"a,b\n1,2\n3,4\n"
+    response = client.post(
+        "/api/sources/upload",
+        data={"project_id": project_id},
+        files={"file": ("dataset.csv", io.BytesIO(csv_bytes), "text/csv")},
+        headers={"x-test-user": user},
+    )
+    assert response.status_code == 201
+    return response.json()["source_id"]
+
+
+def test_private_project_denied_for_other_user(test_context):
+    client, _ = test_context
+    project = _create_project(client, user="user_A", name="A Private", visibility="private")
+
+    denied = client.get(f"/api/projects/{project['id']}", headers={"x-test-user": "user_B"})
+    assert denied.status_code == 404
+
+
+def test_public_project_readable_but_not_mutable_by_other_user(test_context):
+    client, _ = test_context
+    project = _create_project(client, user="user_A", name="A Public", visibility="public")
+
+    readable = client.get(f"/api/projects/{project['id']}", headers={"x-test-user": "user_B"})
+    assert readable.status_code == 200
+
+    denied_update = client.put(
+        f"/api/projects/{project['id']}",
+        json={"description": "hijack"},
+        headers={"x-test-user": "user_B"},
+    )
+    assert denied_update.status_code == 404
+
+    denied_delete = client.delete(f"/api/projects/{project['id']}", headers={"x-test-user": "user_B"})
+    assert denied_delete.status_code == 404
+
+
+def test_list_owner_only_and_discover_excludes_legacy(test_context):
+    client, SessionLocal = test_context
+    _create_project(client, user="user_A", name="A Public Discover", visibility="public")
+    _create_project(client, user="user_A", name="A Private Hidden", visibility="private")
+    _create_project(client, user="user_B", name="B Own 1", visibility="private")
+    _create_project(client, user="user_B", name="B Own 2", visibility="public")
+
+    with SessionLocal() as db:
+        db.add(Project(name="Legacy Public", owner_user_id="legacy", visibility="public"))
+        db.commit()
+
+    mine = client.get("/api/projects", headers={"x-test-user": "user_B"})
+    assert mine.status_code == 200
+    mine_names = {p["name"] for p in mine.json()["projects"]}
+    assert mine_names == {"B Own 1", "B Own 2"}
+
+    discover = client.get("/api/projects/discover", headers={"x-test-user": "user_B"})
+    assert discover.status_code == 200
+    discover_names = {p["name"] for p in discover.json()["projects"]}
+    assert discover_names == {"A Public Discover"}
+
+
+def test_fork_public_project_creates_private_owned_fork(test_context):
+    client, _ = test_context
+    source = _create_project(client, user="user_A", name="Fork Source", visibility="public", with_dag=True)
+    _create_pipeline_simulation(
+        client,
+        user="user_A",
+        project_id=source["id"],
+        dag_version_id=source["current_version"]["id"],
+    )
+
+    fork_response = client.post(f"/api/projects/{source['id']}/fork", headers={"x-test-user": "user_B"})
+    assert fork_response.status_code == 201
+    forked = fork_response.json()
+    assert forked["owner_user_id"] == "user_B"
+    assert forked["visibility"] == "private"
+    assert forked["forked_from_project_id"] == source["id"]
+    assert forked["name"] == "Fork Source (fork)"
+
+    list_pipelines = client.get(
+        "/api/pipelines",
+        params={"project_id": forked["id"]},
+        headers={"x-test-user": "user_B"},
+    )
+    assert list_pipelines.status_code == 200
+    assert len(list_pipelines.json()["pipelines"]) == 1
+
+
+def test_fork_upload_backed_project_is_blocked(test_context):
+    client, _ = test_context
+    source = _create_project(client, user="user_A", name="Upload Fork Source", visibility="public")
+    source_id = _upload_source(client, user="user_A", project_id=source["id"])
+
+    create_pipeline = client.post(
+        "/api/pipelines",
+        json={
+            "project_id": source["id"],
+            "name": "Upload Pipeline",
+            "source": {"type": "upload", "source_id": source_id},
+        },
+        headers={"x-test-user": "user_A"},
+    )
+    assert create_pipeline.status_code == 201
+
+    fork_response = client.post(f"/api/projects/{source['id']}/fork", headers={"x-test-user": "user_B"})
+    assert fork_response.status_code == 400
+    assert "upload-backed" in fork_response.json()["detail"]
+
+
+def test_fork_unreadable_project_returns_404(test_context):
+    client, _ = test_context
+    source = _create_project(client, user="user_A", name="Private Source", visibility="private")
+
+    fork_response = client.post(f"/api/projects/{source['id']}/fork", headers={"x-test-user": "user_B"})
+    assert fork_response.status_code == 404
+
+
+def test_pipeline_access_is_scoped_through_project_access(test_context):
+    client, _ = test_context
+    source = _create_project(client, user="user_A", name="Pipeline Scoped", visibility="private", with_dag=True)
+    pipeline = _create_pipeline_simulation(
+        client,
+        user="user_A",
+        project_id=source["id"],
+        dag_version_id=source["current_version"]["id"],
+    )
+
+    denied_read = client.get(f"/api/pipelines/{pipeline['pipeline_id']}", headers={"x-test-user": "user_B"})
+    assert denied_read.status_code == 404
+
+    make_public = client.put(
+        f"/api/projects/{source['id']}",
+        json={"visibility": "public"},
+        headers={"x-test-user": "user_A"},
+    )
+    assert make_public.status_code == 200
+
+    allowed_read = client.get(f"/api/pipelines/{pipeline['pipeline_id']}", headers={"x-test-user": "user_B"})
+    assert allowed_read.status_code == 200
+
+    denied_write = client.post(
+        f"/api/pipelines/{pipeline['pipeline_id']}/versions/{pipeline['current_version_id']}/steps",
+        json={
+            "step": {
+                "type": "formula",
+                "output_column": "x2",
+                "params": {"expression": "income * 2"},
+            }
+        },
+        headers={"x-test-user": "user_B"},
+    )
+    assert denied_write.status_code == 404
+
+
+def test_fork_name_retry_limit_returns_409(test_context):
+    client, _ = test_context
+    source = _create_project(client, user="user_A", name="Name Collision", visibility="public")
+
+    _create_project(client, user="user_A", name="Name Collision (fork)", visibility="private")
+    for attempt in range(2, 11):
+        _create_project(client, user="user_A", name=f"Name Collision (fork {attempt})", visibility="private")
+
+    fork_response = client.post(f"/api/projects/{source['id']}/fork", headers={"x-test-user": "user_B"})
+    assert fork_response.status_code == 409


### PR DESCRIPTION
## Summary
Implements tenant-scoped authorization with project visibility controls and authenticated forking capabilities.

## Changes

### Schema & Migration
- **New columns on `projects` table:**
  - `owner_user_id` (TEXT, non-null) - Clerk user ID as tenant key
  - `visibility` (TEXT, non-null, default `"private"`) - Controls project discoverability
  - `forked_from_project_id` (UUID, nullable) - Tracks fork lineage
- **New indexes:** `owner_user_id`, `visibility`, `forked_from_project_id`
- **Backfill:** Existing projects set to `owner_user_id="legacy"` and `visibility="private"`
- **Preserved:** Global `projects.name` uniqueness constraint unchanged

### Authorization System
- **Centralized access control** (`app/core/project_access.py`):
  - `require_project_read()` - Grants access to owner OR public projects, raises `404` otherwise
  - `require_project_owner()` - Grants access to owner only, raises `404` otherwise
  - `raise_not_found()` - Canonical `404` helper prevents authz leakage
- **Enforcement:**
  - All project/pipeline routes now use centralized helpers
  - No ad-hoc authz `404` construction in route handlers
  - Pipeline operations always gated by parent project access

### API Changes
- **Preserved:** `/api/projects` remains owner-only for backward compatibility
- **New:** `GET /api/projects/discover` - Returns public projects not owned by caller (excludes legacy projects)
- **New:** `POST /api/projects/{project_id}/fork` - Authenticated forking with the following semantics:
  - ✅ Allowed if source is readable (owner or public)
  - ✅ Creates private fork owned by caller
  - ✅ Copies: project metadata, DAG versions, pipelines, pipeline versions (with ID remapping)
  - ❌ Does NOT copy: uploads, UX events, model fits, artifacts
  - ❌ Blocks upload-backed projects with deterministic `400` error
  - 🔄 Fork naming: `"Source (fork)"` → `"Source (fork 2)"` (max 10 attempts)

### Route Updates
- **Projects:** All read/write operations use centralized authz
- **Pipelines:** Resolve parent project first, then enforce read/write rules
- **Sources:** Upload operations now require project ownership

## Testing
- ✅ 332 tests passing
- New integration tests cover:
  - Cross-tenant access (private projects return `404`, public projects return `200`)
  - Cross-tenant mutation denied (`404`)
  - Discovery endpoint excludes legacy and owned projects
  - Fork creation, naming collisions, upload blocking
  - Pipeline authz via parent project
- Migration tests verify schema changes and backfill behavior

## Migration Notes
- Migration file: `a7c1f2d4e9b3_add_tenant_visibility_and_forking.py`
- **Safe to run:** Backfills existing data, adds non-nullable columns with defaults
- **No downtime expected:** Schema changes are additive

## Breaking Changes
None - all existing endpoints maintain backward compatibility.

## Future Considerations
- [ ] Add pagination to `/api/projects/discover` when project count grows
- [ ] Consider fork count/popularity metrics for discovery ranking
- [ ] Evaluate deprecation path for legacy-owned projects
