### PR TITLE
Authorization hardening: owner scoping + admin override

### DIFF
--- a/backend/app/api/routes/pipelines.py
+++ b/backend/app/api/routes/pipelines.py
@@ -225,12 +225,19 @@ def create_pipeline(
             source = crud.get_uploaded_source(db, request.source.source_id)
             if not source:
                 raise_not_found()
-            if source.created_by != user_id:
-                raise_not_found()
             if source.project_id != request.project_id:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail="Uploaded source must belong to the target project",
+                )
+        else:
+            dag_version = crud.get_version(db, request.source.dag_version_id)
+            if not dag_version:
+                raise_not_found()
+            if dag_version.project_id != request.project_id:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="DAG version must belong to the target project",
                 )
 
         result = pipeline_service.create_pipeline(

--- a/backend/app/api/routes/projects.py
+++ b/backend/app/api/routes/projects.py
@@ -327,15 +327,18 @@ def list_projects(
     skip: int = 0,
     limit: int = 100,
     db: Session = Depends(get_db),
-    current_user: dict[str, str] = Depends(current_user_context),
+    current_user: dict[str, Any] = Depends(current_user_context),
 ) -> ProjectListResponse:
-    """List projects owned by current user."""
-    projects = crud.list_projects_for_owner(
-        db,
-        owner_user_id=current_user["user_id"],
-        skip=skip,
-        limit=limit,
-    )
+    """List projects visible to current user."""
+    if current_user["is_admin"]:
+        projects = crud.list_projects(db, skip=skip, limit=limit)
+    else:
+        projects = crud.list_projects_for_owner(
+            db,
+            owner_user_id=current_user["user_id"],
+            skip=skip,
+            limit=limit,
+        )
     project_responses = [_serialize_project(project) for project in projects]
     return ProjectListResponse(projects=project_responses, total=len(project_responses))
 

--- a/backend/app/api/routes/sources.py
+++ b/backend/app/api/routes/sources.py
@@ -131,8 +131,7 @@ def get_source(
     source = crud.get_uploaded_source(db, source_id)
     if not source:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Source not found")
-    if source.created_by != user_id:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+    require_project_owner(db, source.project_id, user_id)
     return SourceMetadataResponse(
         id=source.id,
         project_id=source.project_id,
@@ -153,7 +152,8 @@ def list_sources(
     user: dict[str, Any] = Depends(require_auth),
 ) -> SourceListResponse:
     user_id = require_user_id(user)
-    rows = crud.list_uploaded_sources(db, project_id=project_id, created_by=user_id)
+    require_project_owner(db, project_id, user_id)
+    rows = crud.list_uploaded_sources(db, project_id=project_id)
     return SourceListResponse(
         sources=[
             SourceMetadataResponse(
@@ -182,8 +182,7 @@ def delete_source(
     source = crud.get_uploaded_source(db, source_id)
     if not source:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Source not found")
-    if source.created_by != user_id:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+    require_project_owner(db, source.project_id, user_id)
 
     if source.storage_uri:
         try:

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -5,10 +5,13 @@ from typing import Any
 import jwt
 from fastapi import Depends, HTTPException, Request, status
 from jwt import PyJWKClient
+from sqlalchemy.orm import Session
 
 from app.core.config import settings
+from app.db.models import ModelFit, Pipeline, PipelineVersion, Project, UploadedSource
 
 logger = logging.getLogger(__name__)
+LEGACY_OWNER_USER_ID = "legacy"
 
 # Global cache for JWKS clients (one per issuer domain)
 _jwks_clients: dict[str, PyJWKClient] = {}
@@ -121,9 +124,77 @@ def require_user_id(user: dict[str, Any]) -> str:
     return user_id
 
 
-def current_user_context(user: dict[str, Any] = Depends(require_auth)) -> dict[str, str]:
+def _admin_user_id_set() -> set[str]:
+    return {value.strip() for value in settings.admin_user_ids.split(",") if value.strip()}
+
+
+def is_admin(user: dict[str, Any]) -> bool:
+    return require_user_id(user) in _admin_user_id_set()
+
+
+def is_admin_user_id(user_id: str) -> bool:
+    return user_id in _admin_user_id_set()
+
+
+def _not_found(detail: str) -> HTTPException:
+    return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail)
+
+
+def _can_access_project(project: Project, user: dict[str, Any]) -> bool:
+    if is_admin(user):
+        return True
+    user_id = require_user_id(user)
+    if project.owner_user_id == LEGACY_OWNER_USER_ID:
+        return False
+    return project.owner_user_id == user_id
+
+
+def ensure_project_access(db: Session, project_id: str, user: dict[str, Any]) -> Project:
+    project = db.get(Project, project_id)
+    if not project or not _can_access_project(project, user):
+        raise _not_found("Project not found")
+    return project
+
+
+def ensure_pipeline_access(db: Session, pipeline_id: str, user: dict[str, Any]) -> Pipeline:
+    pipeline = db.get(Pipeline, pipeline_id)
+    if not pipeline:
+        raise _not_found("Pipeline not found")
+    ensure_project_access(db, pipeline.project_id, user)
+    return pipeline
+
+
+def ensure_pipeline_version_access(db: Session, version_id: str, user: dict[str, Any]) -> PipelineVersion:
+    version = db.get(PipelineVersion, version_id)
+    if not version:
+        raise _not_found("Pipeline version not found")
+    ensure_pipeline_access(db, version.pipeline_id, user)
+    return version
+
+
+def ensure_model_fit_access(db: Session, model_id: str, user: dict[str, Any]) -> ModelFit:
+    model_fit = db.get(ModelFit, model_id)
+    if not model_fit:
+        raise _not_found("Model not found")
+    ensure_pipeline_version_access(db, model_fit.pipeline_version_id, user)
+    return model_fit
+
+
+def ensure_uploaded_source_access(db: Session, source_id: str, user: dict[str, Any]) -> UploadedSource:
+    source = db.get(UploadedSource, source_id)
+    if not source:
+        raise _not_found("Source not found")
+    ensure_project_access(db, source.project_id, user)
+    return source
+
+
+def current_user_context(user: dict[str, Any] = Depends(require_auth)) -> dict[str, Any]:
     """Return normalized current-user context for route dependencies."""
-    return {"user_id": require_user_id(user)}
+    user_id = require_user_id(user)
+    return {
+        "user_id": user_id,
+        "is_admin": is_admin_user_id(user_id),
+    }
 
 
 # Alias for compatibility

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -17,6 +17,7 @@ class Settings(BaseSettings):
     auth_bypass: bool = False  # Dev-only bypass for local runs
     clerk_issuer: str = ""  # Expected issuer domain, e.g., "https://clerk.data-simulator.com"
                              # Leave empty to accept any issuer (less secure, backward compatible)
+    admin_user_ids: str = ""  # Comma-separated Clerk user IDs with admin override access
 
     # CORS - comma-separated list of allowed origins, or "*" for all (default)
     # WARNING: "*" allows all origins. In production, set to your specific domain(s).

--- a/backend/app/core/project_access.py
+++ b/backend/app/core/project_access.py
@@ -5,6 +5,7 @@ from typing import NoReturn
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
+from app.core.auth import is_admin_user_id
 from app.db.models import Project
 
 
@@ -18,6 +19,10 @@ def require_project_read(db: Session, project_id: str, user_id: str) -> Project:
     project = db.get(Project, project_id)
     if not project:
         raise_not_found()
+    if is_admin_user_id(user_id):
+        return project
+    if project.owner_user_id == "legacy":
+        raise_not_found()
     if project.owner_user_id == user_id or project.visibility == "public":
         return project
     raise_not_found()
@@ -27,6 +32,10 @@ def require_project_owner(db: Session, project_id: str, user_id: str) -> Project
     """Return project if current user owns it, else raise not found."""
     project = db.get(Project, project_id)
     if not project:
+        raise_not_found()
+    if is_admin_user_id(user_id):
+        return project
+    if project.owner_user_id == "legacy":
         raise_not_found()
     if project.owner_user_id == user_id:
         return project

--- a/backend/app/db/crud.py
+++ b/backend/app/db/crud.py
@@ -40,7 +40,7 @@ def list_projects_for_owner(
     """List projects owned by a specific user."""
     stmt = (
         select(Project)
-        .where(Project.owner_user_id == owner_user_id)
+        .where(Project.owner_user_id == owner_user_id, Project.owner_user_id != "legacy")
         .offset(skip)
         .limit(limit)
         .order_by(Project.updated_at.desc())

--- a/backend/tests/test_modeling_api_authz.py
+++ b/backend/tests/test_modeling_api_authz.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import Request
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.core.auth import require_auth
+from app.core.config import settings
+from app.db.database import Base, get_db
+from app.main import app
+
+
+@pytest.fixture(scope="function")
+def client():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    original_admin_user_ids = settings.admin_user_ids
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    async def override_require_auth(request: Request):
+        user = request.headers.get("x-test-user", "test-user")
+        return {"sub": user}
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[require_auth] = override_require_auth
+
+    with TestClient(app) as test_client:
+        yield test_client
+
+    settings.admin_user_ids = original_admin_user_ids
+    app.dependency_overrides.clear()
+    Base.metadata.drop_all(bind=engine)
+    engine.dispose()
+
+
+def _create_pipeline(client: TestClient, user: str) -> str:
+    dag = {
+        "schema_version": "1.0",
+        "nodes": [
+            {
+                "id": "x",
+                "name": "X",
+                "kind": "stochastic",
+                "dtype": "float",
+                "scope": "row",
+                "distribution": {"type": "normal", "params": {"mu": 0, "sigma": 1}},
+            },
+            {
+                "id": "y",
+                "name": "Y",
+                "kind": "stochastic",
+                "dtype": "float",
+                "scope": "row",
+                "distribution": {"type": "normal", "params": {"mu": 5, "sigma": 2}},
+            },
+        ],
+        "edges": [],
+        "metadata": {"sample_size": 100, "seed": 42},
+    }
+    project = client.post("/api/projects", json={"name": f"{user}-modeling", "dag_definition": dag}, headers={"x-test-user": user})
+    assert project.status_code == 201
+    project_id = project.json()["id"]
+    dag_version_id = project.json()["current_version"]["id"]
+
+    pipeline = client.post(
+        "/api/pipelines",
+        json={
+            "project_id": project_id,
+            "name": f"{user}-pipeline",
+            "source": {
+                "type": "simulation",
+                "dag_version_id": dag_version_id,
+                "seed": 42,
+                "sample_size": 100,
+            },
+        },
+        headers={"x-test-user": user},
+    )
+    assert pipeline.status_code == 201
+    return pipeline.json()["current_version_id"]
+
+
+def _fit_model(client: TestClient, pipeline_version_id: str, user: str) -> str:
+    response = client.post(
+        "/api/modeling/fit",
+        json={
+            "pipeline_version_id": pipeline_version_id,
+            "name": "lr-fit",
+            "model_name": "linear_regression",
+            "target": "y",
+            "features": ["x"],
+            "model_params": {},
+            "split_spec": {"type": "random", "test_size": 0.2, "random_state": 42},
+        },
+        headers={"x-test-user": user},
+    )
+    assert response.status_code == 200
+    return response.json()["model_id"]
+
+
+def test_non_owner_cannot_access_model_fit(client: TestClient):
+    version_id = _create_pipeline(client, "alice")
+    model_id = _fit_model(client, version_id, "alice")
+
+    response = client.get(f"/api/modeling/fits/{model_id}", headers={"x-test-user": "bob"})
+    assert response.status_code == 404
+
+
+def test_admin_can_access_model_fit_across_owners(client: TestClient):
+    settings.admin_user_ids = "admin-user"
+    version_id = _create_pipeline(client, "alice")
+    model_id = _fit_model(client, version_id, "alice")
+
+    response = client.get(f"/api/modeling/fits/{model_id}", headers={"x-test-user": "admin-user"})
+    assert response.status_code == 200
+
+    list_response = client.get("/api/modeling/fits", headers={"x-test-user": "admin-user"})
+    assert list_response.status_code == 200
+    assert list_response.json()["total_count"] >= 1
+

--- a/backend/tests/test_pipeline_upload.py
+++ b/backend/tests/test_pipeline_upload.py
@@ -147,4 +147,3 @@ def test_admin_can_create_pipeline_from_other_users_source(client: TestClient):
         headers={"x-test-user": "admin-user"},
     )
     assert response.status_code == 201
-    original_admin_user_ids = settings.admin_user_ids

--- a/backend/tests/test_sources_api.py
+++ b/backend/tests/test_sources_api.py
@@ -110,4 +110,3 @@ def test_admin_can_access_sources_across_owners(client: TestClient):
     list_admin = client.get("/api/sources", params={"project_id": project_id}, headers={"x-test-user": "admin-user"})
     assert list_admin.status_code == 200
     assert len(list_admin.json()["sources"]) == 1
-    original_admin_user_ids = settings.admin_user_ids


### PR DESCRIPTION
## Summary
This PR implements ownership-scoped authorization with admin override, without changing existing project-name uniqueness behavior.

## What changed
- Added `projects.owner_user_id` (migration + model + index)
  - Migration adds nullable column, backfills unknown ownership to `legacy`, sets NOT NULL, adds index.
- Added admin allowlist config via `DS_ADMIN_USER_IDS`.
- Added centralized authz helpers in `app/core/auth.py`:
  - `is_admin`
  - `ensure_project_access`
  - `ensure_pipeline_access`
  - `ensure_pipeline_version_access`
  - `ensure_model_fit_access`
  - `ensure_uploaded_source_access`
- Enforced project-ownership authorization in protected routes:
  - `projects`, `pipelines`, `sources`, `modeling`
- Normalized unauthorized cross-user access to `404`.
- Enforced legacy policy: non-admin access to `owner_user_id == 'legacy'` returns `404`.
- Upload access control now chains to project ownership (with admin override); `created_by` remains provenance metadata.

## Behavior notes
- Admin list endpoints include all resources, including legacy-owned rows.
- Public read endpoint (`/api/public/...`) remains unchanged.
- Share/unshare management remains owner/admin-gated.

## Tests
Added/updated tests for owner scoping and admin override:
- `tests/test_projects_api.py`
- `tests/test_pipelines_api.py`
- `tests/test_pipeline_upload.py`
- `tests/test_sources_api.py`
- `tests/test_modeling_api_authz.py` (new)

Executed:
- `pytest -q tests/test_projects_api.py tests/test_sources_api.py tests/test_pipeline_upload.py tests/test_pipelines_api.py tests/test_modeling_api_authz.py`
- Result: pass
