### PR TITLE
fix: clean up warning debt, lint errors, and OMP CV bug

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
     """Application settings loaded from environment variables."""
+
+    model_config = SettingsConfigDict(env_file=".env", env_prefix="DS_", extra="ignore")
 
     # API
     app_name: str = "Data Simulator"
@@ -50,10 +52,6 @@ class Settings(BaseSettings):
     # Database
     database_url: str = "sqlite:///./data_simulator.db"
 
-    class Config:
-        env_file = ".env"
-        env_prefix = "DS_"
-        extra = "ignore"
 
 
 settings = Settings()

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -149,7 +149,7 @@ class Pipeline(Base):
         String(50), nullable=False, default="simulation"
     )  # "simulation" | "upload"
     current_version_id: Mapped[str | None] = mapped_column(
-        String(36), ForeignKey("pipeline_versions.id", ondelete="SET NULL"), nullable=True
+        String(36), ForeignKey("pipeline_versions.id", ondelete="SET NULL", use_alter=True), nullable=True
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime, server_default=func.now(), nullable=False

--- a/backend/app/services/model_registry.py
+++ b/backend/app/services/model_registry.py
@@ -801,6 +801,7 @@ EXCLUDED_ESTIMATORS = {
     "GammaRegressor",  # GLM
     "PoissonRegressor",  # GLM
     "TweedieRegressor",  # GLM
+    "OrthogonalMatchingPursuitCV",  # Requires min 2 features (sklearn limitation)
 }
 
 # Category mapping based on module path

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -52,6 +52,12 @@ strict = true
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
+filterwarnings = [
+    'ignore:Field name "schema" in .* shadows an attribute in parent "BaseModel":UserWarning',
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["app"]

--- a/frontend/src/utils/latex.ts
+++ b/frontend/src/utils/latex.ts
@@ -110,13 +110,14 @@ export function distributionToLatex(dist: DistributionConfig | undefined): strin
       return `\\text{LogN}(${mu}, ${sigma}^2)`;
     }
 
-    default:
+    default: {
       // Generic distribution with type name
       const paramList = Object.entries(params)
         .slice(0, 2)
         .map(([, v]) => paramToString(v))
         .join(', ');
       return `\\text{${type}}(${paramList})`;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- **#38** — Wrap `default` switch case in braces in `latex.ts` (no-case-declarations lint)
- **#41** — Eliminate all 39 backend test warnings:
  - Pydantic `class Config` → `model_config = SettingsConfigDict(...)` 
  - Register `slow` pytest mark in `pyproject.toml`
  - Filter Pydantic `schema` field shadow warnings (v1 compat, cosmetic)
  - `use_alter=True` on Pipeline→PipelineVersion FK to resolve SQLAlchemy drop-order cycle
- **#10** — Exclude `OrthogonalMatchingPursuitCV` from model registry (sklearn requires min 2 features)

## Test plan
- [x] Backend: 346 passed, 0 warnings (down from 39)
- [x] Frontend: `eslint src/utils/latex.ts` clean
- [x] OMP registered, OMP-CV excluded from registry

Closes #38, closes #41, closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)